### PR TITLE
Added linting & docs

### DIFF
--- a/.github/.remarkrc
+++ b/.github/.remarkrc
@@ -1,0 +1,15 @@
+{
+    "plugins": [
+        "preset-lint-markdown-style-guide",
+        ["lint-list-item-indent", "space"],
+        ["lint-ordered-list-marker-value", "ordered"],
+        ["lint-no-file-name-irregular-characters", "\\.a-zA-Z0-9-_"],
+        ["stringify", {
+            "bullet": "-",
+            "fences": true,
+            "listItemIndent": "one",
+            "rule": "-"
+        }],
+        ["lint-maximum-line-length", false]
+    ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+/docs/
+*.swp
 *.exe
-
+/node_modules/
+/package-lock.json

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,14 @@
+{
+    "plugins": [
+        "preset-lint-markdown-style-guide",
+        ["lint-list-item-indent", "space"],
+        ["lint-ordered-list-marker-value", "ordered"],
+        ["lint-no-file-name-irregular-characters", "\\.a-zA-Z0-9-_"],
+        ["stringify", {
+            "bullet": "-",
+            "fences": true,
+            "listItemIndent": "one",
+            "rule": "-"
+        }]
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,15 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Fixed cloning type error regression introduced when we updated
   `gopkg.in/src-d/go-git.v4`. (!3)
-  
+
 - Changed libs versions in mod file. (!10)
 
 - Added new open sourced Wharf API client
   [github.com/iver-wharf/wharf-api-client-go](https://github.com/iver-wharf/wharf-api-client-go)
   v1.2.0. (!11, !14)
 
-- Added `buildclient.Client` with posting logs and build statuses functionality. (!11)
+- Added `buildclient.Client` with posting logs and build statuses
+  functionality. (!11)
 
 - Added `ContainerReadyWaiter` interface with implementation. (!12)
 
@@ -49,17 +50,21 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Changed `StepType`. New parsing delivered. String method implemented. (!15)
 
-- Added `ContainerStateWatcher` interface with implementation for done container and ready container. (!16)
+- Added `ContainerStateWatcher` interface with implementation for done
+  container and ready container. (!16)
 
-- Changed `ContainerReadyWaiter` to use `ContainerStateWatcher` and renamed to `ContainerWaiter`. (!16)
+- Changed `ContainerReadyWaiter` to use `ContainerStateWatcher` and renamed to
+  `ContainerWaiter`. (!16)
 
 - Added delete pod functionality. (!16)
 
-- Added reading variables from `Environment` section in wharf-ci.yml file. (!17)
+- Added reading variables from `Environment` section in wharf-ci.yml file.
+  (!17)
 
 - Added replacement variables functionality for the step. (!17)
 
-- Added `BuiltinVarType` type. Grabbed variables from URL and git repository. (!18)
+- Added `BuiltinVarType` type. Grabbed variables from URL and git repository.
+  (!18)
 
 - Added `Input` array parsing from `wharf-ci.yml` file. (!19)
 
@@ -88,17 +93,20 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
   - `wharf setup`
 
-  - `wharf wharf-ci` *Ci application to generate .wharf-ci.yml files and execute
-    them against a kubernetes cluster*
+  - `wharf wharf-ci`
+    *Ci application to generate .wharf-ci.yml files and execute them against a
+    kubernetes cluster*
 
-  - `wharf run` *Run the specified .wharf-ci.yml file against kubernetes*
+  - `wharf run`
+    *Run the specified .wharf-ci.yml file against kubernetes*
 
 - Added global arguments: (07abc2a4, 021c02ce)
 
-  - `wharf --loglevel info` *Show debug information*
+  - `wharf --loglevel info`
+    *Show debug information*
 
-  - `wharf --kubeconfig ~/.kube/config` *Path to kubeconfig file*
+  - `wharf --kubeconfig ~/.kube/config`
+    *Path to kubeconfig file*
 
 - Added CLI arguments parsing via
   [github.com/spf13/cobra](https://github.com/spf13/cobra). (07abc2a4)
-

--- a/README.md
+++ b/README.md
@@ -19,3 +19,65 @@ A command-line interface to run tasks specified in a `.wharf-ci.yml` file.
 ### Serve
 
 `wharf serve --listen :8080 --kubeconfig=~/.kube/config`
+
+## Components
+
+- HTTP API using the [gin-gonic/gin](https://github.com/gin-gonic/gin)
+  web framework.
+
+- Command-line parsing using [spf13/cobra](https://github.com/spf13/cobra)
+
+- Kubernetes access using [k8s.io/client-go](https://github.com/kubernetes/client-go)
+
+- Git interface using [go-git/go-git](https://github.com/go-git/go-git)
+
+## Development
+
+1. Install Go 1.13 or later: <https://golang.org/>
+
+2. Start hacking with your favorite tool. For example VS Code, GoLand,
+   Vim, Emacs, or whatnot.
+
+## Linting Golang
+
+- Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
+- Requires Revive to be installed: <https://revive.run/>
+
+```sh
+go get -u github.com/mgechev/revive
+```
+
+```sh
+npm run lint-go
+```
+
+## Linting markdown
+
+- Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
+
+```sh
+npm install
+
+npm run lint-md
+
+# Some errors can be fixed automatically. Keep in mind that this updates the
+# files in place.
+npm run lint-md-fix
+```
+
+## Linting
+
+You can lint all of the above at the same time by running:
+
+```sh
+npm run lint
+
+# Some errors can be fixed automatically. Keep in mind that this updates the
+# files in place.
+npm run lint-fix
+```
+
+---
+
+Maintained by [Iver](https://www.iver.com/en).
+Licensed under the [MIT license](./LICENSE).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "lint": "\"$npm_execpath\" run lint-md && \"$npm_execpath\" run lint-go",
+    "lint-fix": "\"$npm_execpath\" run lint-md-fix",
+    "lint-md": "remark . .github",
+    "lint-md-fix": "remark . .github -o",
+    "lint-go": "revive -formatter stylish -config revive.toml ./..."
+  },
+  "devDependencies": {
+    "remark-cli": "^9.0.0",
+    "remark-lint": "^8.0.0",
+    "remark-preset-lint-markdown-style-guide": "^4.0.0"
+  }
+}

--- a/revive.toml
+++ b/revive.toml
@@ -1,0 +1,31 @@
+# Taken from https://revive.run/docs#recommended-configuration
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.8
+errorCode = 0
+warningCode = 0
+
+[rule.blank-imports]
+[rule.context-as-argument]
+[rule.context-keys-type]
+[rule.dot-imports]
+[rule.error-return]
+[rule.error-strings]
+[rule.error-naming]
+[rule.exported]
+[rule.if-return]
+[rule.increment-decrement]
+[rule.var-naming]
+[rule.var-declaration]
+[rule.package-comments]
+[rule.range]
+[rule.receiver-naming]
+[rule.time-naming]
+[rule.unexported-return]
+[rule.indent-error-flow]
+[rule.errorf]
+[rule.empty-block]
+[rule.superfluous-else]
+[rule.unused-parameter]
+[rule.unreachable-code]
+[rule.redefines-builtin-id]


### PR DESCRIPTION
## Summary

- Added remark-lint & revive, the Markdown & Go linters we're using in other repos

- Fixed linting issues in CHANGELOG.md, as that was the only file that had Markdown linting issues. I did not touch any Go linting issues.

- Updated README.md to show how to lint and also add extra docs that I missed when moving the repo such as the "Components" header and license notice.

## Motivation

Linting is nice to have
