### PR TITLE
Changed code so it compiles

### DIFF
--- a/pkg/core/wharfyml/builddefinition_test.go
+++ b/pkg/core/wharfyml/builddefinition_test.go
@@ -54,7 +54,7 @@ deploy:
       namespace: ${namespace}
       cluster: ${cluster}`
 
-	sut, err := parseContent([]byte(buildDef))
+	sut, err := parseContent(buildDef)
 	require.Nil(suite.T(), err)
 
 	suite.sut = sut

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -169,4 +169,6 @@ func (r Runner) RunDefinition(
 			WithString("newStatus", wharfapi.BuildCompleted.String()).
 			Message("Failed to update build status.")
 	}
+
+	return nil
 }


### PR DESCRIPTION
- \[ ] ~~I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs~~ I don't deem this CHANGELOG-worthy

## Summary

- Added missing `return` statement in `pkg/run/run.go`
- Fixed unneeded `[]byte` conversion in `pkg/core/wharfyml/builddefinition_test.go` as `parseContent` takes a `string`

## Motivation

This is only to get the tests running. The project is still not in a working state, but at least now the tests pass.

My guess is that there were some invalid merge conflict resolution made (by me)