### PR TITLE
Added Makefile for linting and building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: install tidy deps \
+	lint lint-md lint-go \
+	lint-fix lint-md-fix
+
+ifeq ($(OS),Windows_NT)
+wharf.exe:
+	go build -o wharf.exe
+else
+wharf:
+	go build -o wharf
+endif
+
+install:
+	go install
+
+tidy:
+	go mod tidy
+
+deps:
+	go install github.com/mgechev/revive@latest
+	go install golang.org/x/tools/cmd/goimports@latest
+	npm install
+
+lint: lint-md lint-go
+lint-fix: lint-md-fix
+
+lint-md:
+	npx remark . .github
+
+lint-md-fix:
+	npx remark . .github -o
+
+lint-go:
+	revive -formatter stylish -config revive.toml ./...

--- a/README.md
+++ b/README.md
@@ -26,43 +26,33 @@ A command-line interface to run tasks specified in a `.wharf-ci.yml` file.
 2. Start hacking with your favorite tool. For example VS Code, GoLand,
    Vim, Emacs, or whatnot.
 
-## Linting Golang
+3. Install formatter and linters:
 
-- Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
-- Requires Revive to be installed: <https://revive.run/>
-
-```sh
-go get -u github.com/mgechev/revive
-```
-
-```sh
-npm run lint-go
-```
-
-## Linting markdown
-
-- Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
-
-```sh
-npm install
-
-npm run lint-md
-
-# Some errors can be fixed automatically. Keep in mind that this updates the
-# files in place.
-npm run lint-md-fix
-```
+   ```sh
+   go install github.com/mgechev/revive@latest
+   go install golang.org/x/tools/cmd/goimports@latest
+   npm install
+   ```
 
 ## Linting
 
 You can lint all of the above at the same time by running:
 
 ```sh
-npm run lint
+make lint
 
-# Some errors can be fixed automatically. Keep in mind that this updates the
-# files in place.
-npm run lint-fix
+make lint-go # only lint Go code
+make lint-md # only lint Markdown files
+```
+
+Some errors can be fixed automatically. Keep in mind that this updates the
+files in place.
+
+```sh
+make lint-fix
+
+#make lint-fix-go # Go linter does not support fixes
+make lint-fix-md # only lint and fix Markdown files
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,11 +1,4 @@
 {
-  "scripts": {
-    "lint": "\"$npm_execpath\" run lint-md && \"$npm_execpath\" run lint-go",
-    "lint-fix": "\"$npm_execpath\" run lint-md-fix",
-    "lint-md": "remark . .github",
-    "lint-md-fix": "remark . .github -o",
-    "lint-go": "revive -formatter stylish -config revive.toml ./..."
-  },
   "devDependencies": {
     "remark-cli": "^9.0.0",
     "remark-lint": "^8.0.0",


### PR DESCRIPTION
## Summary

- Added Makefile
- Removed NPM scripts from `package.json`, instead rely on Makefile targets
- Simplified linting docs a lot

## Motivation

Trying something out here with relying on Makefile instead of NPM scripts.

If this gets approved, then I will change the other repos to also use Makefile instead of NPM scripts.
