### PR TITLE
Improved logging with Cobra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Removed commands `init`, `setup`, and `serve`. (#8)
 
+- Changed logging on CLI errors (ex "unknown command") to be more terse. (#34)
+
 ## v0.6.0 (2020-02-04)
 
 - Added initial proof of concept to build in Kubernetes, based on a

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-var hasInitLogging bool
+var isLoggingInitialized bool
 var loglevel string
 var Kubeconfig *rest.Config
 var kubeconfigPath string
@@ -38,9 +38,7 @@ var rootCmd = &cobra.Command{
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		if !hasInitLogging {
-			initLogging()
-		}
+		initLoggingIfNeeded()
 		log.Error().Message(err.Error())
 		os.Exit(1)
 	}
@@ -52,6 +50,12 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&loglevel, "loglevel", "info", "Show debug information")
 	rootCmd.PersistentFlags().StringVar(&kubeconfigPath, "kubeconfig", filepath.Join(home, ".kube", "config"), "Path to kubeconfig file")
 	rootCmd.PersistentFlags().StringVar(&Namespace, "namespace", "default", "Namespace to spawn resources in")
+}
+
+func initLoggingIfNeeded() {
+	if !isLoggingInitialized {
+		initLogging()
+	}
 }
 
 func initLogging() {
@@ -72,7 +76,7 @@ func initLogging() {
 	} else {
 		log.Debug().WithStringer("loglevel", parsedLogLevel).Message("Setting log-level.")
 	}
-	hasInitLogging = true
+	isLoggingInitialized = true
 }
 
 func homeDir() string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,29 +13,20 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+var hasInitLogging bool
 var loglevel string
 var Kubeconfig *rest.Config
 var kubeconfigPath string
 var Namespace string
 
 var rootCmd = &cobra.Command{
-	Use:   "wharf-ci",
-	Short: "Ci application to generate .wharf-ci.yml files and execute them against a kubernetes cluster",
-	Long:  ``,
+	SilenceErrors: true,
+	SilenceUsage:  true,
+	Use:           "wharf-cmd",
+	Short:         "Ci application to generate .wharf-ci.yml files and execute them against a kubernetes cluster",
+	Long:          ``,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-
-		parsedLogLevel, err := parseLevel(loglevel)
-		if err != nil {
-			parsedLogLevel = logger.LevelInfo
-		}
-		logger.AddOutput(parsedLogLevel, consolepretty.Default)
-
-		if err != nil {
-			log.Warn().WithStringer("loglevel", parsedLogLevel).Message("Unable to parse loglevel.")
-		} else {
-			log.Debug().WithStringer("loglevel", parsedLogLevel).Message("Setting log-level.")
-		}
-
+		var err error
 		Kubeconfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 		if err != nil {
 			log.Warn().WithError(err).Message("Failed to load kube-config")
@@ -47,15 +38,41 @@ var rootCmd = &cobra.Command{
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		log.Panic().WithError(err).Message("Execution failed.")
+		if !hasInitLogging {
+			initLogging()
+		}
+		log.Error().Message(err.Error())
+		os.Exit(1)
 	}
 }
 
 func init() {
+	cobra.OnInitialize(initLogging)
 	home := homeDir()
 	rootCmd.PersistentFlags().StringVar(&loglevel, "loglevel", "info", "Show debug information")
 	rootCmd.PersistentFlags().StringVar(&kubeconfigPath, "kubeconfig", filepath.Join(home, ".kube", "config"), "Path to kubeconfig file")
 	rootCmd.PersistentFlags().StringVar(&Namespace, "namespace", "default", "Namespace to spawn resources in")
+}
+
+func initLogging() {
+	parsedLogLevel, err := parseLevel(loglevel)
+	if err != nil {
+		parsedLogLevel = logger.LevelInfo
+	}
+	logConfig := consolepretty.DefaultConfig
+	if parsedLogLevel != logger.LevelDebug {
+		logConfig.DisableCaller = true
+		logConfig.DisableDate = true
+		logConfig.ScopeMinLengthAuto = false
+	}
+	logger.AddOutput(parsedLogLevel, consolepretty.New(logConfig))
+	if err != nil {
+		log.Warn().WithStringer("loglevel", parsedLogLevel).Message("Unable to parse loglevel. Defaulting to 'INFO'.")
+		parsedLogLevel = logger.LevelInfo
+	} else {
+		log.Debug().WithStringer("loglevel", parsedLogLevel).Message("Setting log-level.")
+	}
+	hasInitLogging = true
 }
 
 func homeDir() string {


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed so Cobra doesn't print help text and its own error output whenever a cmd returns an error.
- Changed error on cmd to only print as message, instead of as the `.WithError()` field.
- Changed name of root cmd from `wharf-ci` to `wharf-cmd` as the binary is named `wharf-cmd` (explored further in #35)

## Motivation

Before:

```console
$ wharf-cmd non-existing-cmd
Error: unknown command "non-existing-cmd" for "wharf-ci"
Run 'wharf-ci --help' for usage.
panic: Execution failed.

goroutine 1 [running]:
github.com/iver-wharf/wharf-core/pkg/logger.panicString({0x102a038, 0xead8c0})
	/home/kalle/go/pkg/mod/github.com/iver-wharf/wharf-core@v1.3.0/pkg/logger/logger.go:149 +0x2d
github.com/iver-wharf/wharf-core/pkg/logger.event.Message({0x4, {0x1923360, 0x0, 0x0}, 0x10b6458}, {0x102a038, 0x11})
	/home/kalle/go/pkg/mod/github.com/iver-wharf/wharf-core@v1.3.0/pkg/logger/event.go:196 +0xe3
github.com/iver-wharf/wharf-cmd/cmd.Execute()
	/home/kalle/dev/wharf/wharf-cmd/cmd/root.go:50 +0x76
main.main()
	/home/kalle/dev/wharf/wharf-cmd/main.go:6 +0x17
```

After:

```console
$ wharf-cmd non-existing-cmd
[ERROR] unknown command "non-existing-cmd" for "wharf-cmd"
```
