### PR TITLE
Added goimports linting to 'make lint-go'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ deps:
 	npm install
 
 lint: lint-md lint-go
-lint-fix: lint-md-fix
+lint-fix: lint-md-fix lint-go-fix
 
 lint-md:
 	npx remark . .github
@@ -31,4 +31,8 @@ lint-md-fix:
 	npx remark . .github -o
 
 lint-go:
+	goimports -d $(shell git ls-files "*.go")
 	revive -formatter stylish -config revive.toml ./...
+
+lint-go-fix:
+	goimports -d -w $(shell git ls-files "*.go")

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install tidy deps \
 	lint lint-md lint-go \
-	lint-fix lint-md-fix
+	lint-fix lint-fix-md lint-fix-go
 
 ifeq ($(OS),Windows_NT)
 wharf.exe:

--- a/Makefile
+++ b/Makefile
@@ -22,17 +22,17 @@ deps:
 	npm install
 
 lint: lint-md lint-go
-lint-fix: lint-md-fix lint-go-fix
+lint-fix: lint-fix-md lint-fix-go
 
 lint-md:
 	npx remark . .github
 
-lint-md-fix:
+lint-fix-md:
 	npx remark . .github -o
 
 lint-go:
 	goimports -d $(shell git ls-files "*.go")
 	revive -formatter stylish -config revive.toml ./...
 
-lint-go-fix:
+lint-fix-go:
 	goimports -d -w $(shell git ls-files "*.go")

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ A command-line interface to run tasks specified in a `.wharf-ci.yml` file.
 
 ## Linting
 
-You can lint all of the above at the same time by running:
-
 ```sh
+make deps # download linting dependencies
+
 make lint
 
 make lint-go # only lint Go code

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ files in place.
 ```sh
 make lint-fix
 
-#make lint-fix-go # Go linter does not support fixes
+make lint-fix-go # only lint and fix Go files
 make lint-fix-md # only lint and fix Markdown files
 ```
 


### PR DESCRIPTION
## Summary

- Adds `goimports` to `lint-go` target in `Makefile`
- Adds `goimports` to new `lint-go-fix` target in `Makefile`

## Motivation

Based on discussion: https://github.com/iver-wharf/wharf-api-client-go/pull/34#issuecomment-1033859141
