### PR TITLE
Cut await from last CR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Changed logging on CLI errors (ex "unknown command") to be more terse. (#34)
 
+- Changed to trim away everything before the last CR (carriage return)
+  character in a log line from a Kubernetes pod. (#49)
+
 - Changed location of packages and code files: (#44)
 
   - File `pkg/core/utils/variablesreplacer.go` to its own package in `pkg/varsub`

--- a/pkg/worker/k8srunner.go
+++ b/pkg/worker/k8srunner.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/iver-wharf/wharf-cmd/pkg/tarutil"
@@ -189,7 +190,12 @@ func (r k8sStepRunner) streamLogsUntilCompleted(ctx context.Context, podName str
 	podLog := logger.NewScoped(contextStageStepName(ctx))
 	scanner := bufio.NewScanner(readCloser)
 	for scanner.Scan() {
-		podLog.Info().Message(scanner.Text())
+		txt := scanner.Text()
+		idx := strings.LastIndexByte(txt, '\r')
+		if idx != -1 {
+			txt = txt[idx+1:]
+		}
+		podLog.Info().Message(txt)
 	}
 	return scanner.Err()
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed scanned logs to cut everything from the last CR (carriage-return)

## Motivation

This trims down logs such as the `apt update` which contains log lines like (with CR shown as `<CR>`):

`(Reading database ...<CR>(Reading database ... 5%<CR>(Reading database ... 10%<CR>(Reading database ... 15%<CR>(Reading database ... 20%<CR>(Reading database ... 25%<CR>(Reading database ... 30%<CR>(Reading database ... 35%<CR>(Reading database ... 40%<CR>(Reading database ... 45%<CR>(Reading database ... 50%<CR>(Reading database ... 55%<CR>(Reading database ... 60%<CR>(Reading database ... 65%<CR>(Reading database ... 70%<CR>(Reading database ... 75%<CR>(Reading database ... 80%<CR>(Reading database ... 85%<CR>(Reading database ... 90%<CR>(Reading database ... 95%<CR>(Reading database ... 100%<CR>(Reading database ... 4127 files and directories currently installed.)`

And turns it into:

`(Reading database ... 4127 files and directories currently installed.)`

Fixes:

- The CR resets the cursor to the start of the line, overriding the wharf-core's prefix of `[INFO |build/myBuild] ` text.

- Shrinks the data we store, as we don't want those log lines anyway

## Alternative solution

Override the `bufio.Scanner` to split on both LF and CR (by default it only splits on LF), this way we could stream the incremental updates as well.

Maybe something to consider in the future on how to implement. That's a "nice to have" feature to even let those log lines update the same line even in the wharf-web frontend.

This is the simpler solution though, of just discarding everything but the last message in a CR chain.
