### PR TITLE
Read pod logs on failed start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added build result (logs, status updates) caching via file system. New
   package in `pkg/resultstore`. (#43)
 
+- Fixed `wharf run` not reading a pod's logs when it fails immediately on start.
+  (#50)
+
 - Changed from `github.com/sirupsen/logrus` to
   `github.com/iver-wharf/wharf-core/pkg/logger` for logging. (#2, #7)
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed to read pod logs from a pod if it failed to start.

## Motivation

Sometimes it errors out before wharf-cmd even gets a chance to detect that it was running in the first place.

Such is the case when the application errors out immediately, such as on invalid CLI arguments.
