### PR TITLE
Fixed to fail on config error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Fixed `wharf run` not reading a pod's logs when it fails immediately on start.
   (#50)
 
+- Fixed `wharf run` not failing due to pod config errors, such as "secret
+  'cluster-config' not found" in `kubectl` steps. (#52)
+
 - Changed from `github.com/sirupsen/logrus` to
   `github.com/iver-wharf/wharf-core/pkg/logger` for logging. (#2, #7)
 

--- a/pkg/worker/k8srunner.go
+++ b/pkg/worker/k8srunner.go
@@ -136,6 +136,10 @@ func (r k8sStepRunner) waitForAppContainerRunningOrDone(ctx context.Context, pod
 				}
 				return true, nil
 			}
+			if c.State.Waiting != nil &&
+				c.State.Waiting.Reason == "CreateContainerConfigError" {
+				return false, fmt.Errorf("config error: %s", c.State.Waiting.Message)
+			}
 			if c.State.Running != nil {
 				return true, nil
 			}


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed wharf-cmd-worker not failing on config error

## Motivation

Config errors occur when the pod references secrets or configmaps that don't exist.

Kubernetes will wait until the configmap exists until it finally starts the container, which translated to wharf-cmd-worker sitting idle waiting for the config error to be resolved by the user.

This behaviour is nice when deploying to kubernetes, but not nice when Wharf just wants to run some ephemeral job pods.

## Preview

```console
$ wharf-cmd run -s nuget
[INFO ] Starting stage.  stages=0/1  stage=nuget
[INFO ] Starting step.  steps=0/1  stage=nuget  step=core-cache
[WARN ] Failed step. Cancelling other steps in stage.  steps=1/1  stage=nuget  step=core-cache  dur=2m39s  error=`wait for app container: config error: secret "wharf-nuget-api-token" not found` (*fmt.wrapError)
[WARN ] Failed stage. Skipping any further stages.  stages=1/1  stage=nuget  dur=2m39s  status=Failed  failed=core-cache  cancelled=``
[INFO ] Done with build.  dur=2m39s  status=Failed
[ERROR] build failed
```
