### PR TITLE
Removed duplicate k8s/core/v1 import

### DIFF
--- a/pkg/worker/k8srunner.go
+++ b/pkg/worker/k8srunner.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 )
@@ -272,7 +271,7 @@ func execInPodPipeStdout(c *rest.Config, namespace, podName, containerName strin
 }
 
 func execInPod(c *rest.Config, namespace, podName string, execOpts *v1.PodExecOptions) (remotecommand.Executor, error) {
-	coreclient, err := corev1client.NewForConfig(c)
+	coreclient, err := corev1.NewForConfig(c)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Removed excess import from `k8s.io/client-go/kubernetes/typed/core/v1`

## Motivation

I tried out [staticcheck](https://staticcheck.io/) which found this issue for us.

```console
$ staticcheck ./...
pkg/worker/k8srunner.go:19:2: package "k8s.io/client-go/kubernetes/typed/core/v1" is being imported more than once (ST1019)
	pkg/worker/k8srunner.go:20:2: other import of "k8s.io/client-go/kubernetes/typed/core/v1"
```

I'm not liking staticcheck **_that_** much as to wanting to spend the effort to introducing it into our CI pipeline. But at least it's good to run it from time to time manually.
