### PR TITLE
Added env var sub support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added new implementation for `.wharf-ci.yml` file parsing that now supports
   returning multiple errors for the whole parsing as well as keep track of the
-  line & column of each parse error. (#48)
+  line & column of each parse error. (#48, #58)
 
 - Added build result (logs, status updates) caching via file system. New
   package in `pkg/resultstore`. (#43)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -64,5 +64,5 @@ func init() {
 
 	runCmd.Flags().StringVarP(&flagRunPath, "path", "p", ".wharf-ci.yml", "Path to .wharf-ci file")
 	runCmd.Flags().StringVarP(&flagStage, "stage", "s", "", "Stage to run (will run all stages if unset)")
-	runCmd.Flags().StringVarP(&flagStage, "environment", "e", "", "Environment selection")
+	runCmd.Flags().StringVarP(&flagEnv, "environment", "e", "", "Environment selection")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -25,7 +25,7 @@ var runCmd = &cobra.Command{
 		}
 		stageRun := worker.NewStageRunner(stepRun)
 		b := worker.New(stageRun)
-		def, errs := wharfyml.ParseFile(flagRunPath)
+		def, errs := wharfyml.ParseFile(flagRunPath, wharfyml.Args{})
 		if len(errs) > 0 {
 			log.Warn().WithInt("errors", len(errs)).Message("Cannot run build due to parsing errors.")
 			for _, err := range errs {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -12,6 +12,7 @@ import (
 
 var flagRunPath string
 var flagStage string
+var flagEnv string
 
 var runCmd = &cobra.Command{
 	Use:   "run",
@@ -25,7 +26,9 @@ var runCmd = &cobra.Command{
 		}
 		stageRun := worker.NewStageRunner(stepRun)
 		b := worker.New(stageRun)
-		def, errs := wharfyml.ParseFile(flagRunPath, wharfyml.Args{})
+		def, errs := wharfyml.ParseFile(flagRunPath, wharfyml.Args{
+			Env: flagEnv,
+		})
 		if len(errs) > 0 {
 			log.Warn().WithInt("errors", len(errs)).Message("Cannot run build due to parsing errors.")
 			for _, err := range errs {
@@ -61,4 +64,5 @@ func init() {
 
 	runCmd.Flags().StringVarP(&flagRunPath, "path", "p", ".wharf-ci.yml", "Path to .wharf-ci file")
 	runCmd.Flags().StringVarP(&flagStage, "stage", "s", "", "Stage to run (will run all stages if unset)")
+	runCmd.Flags().StringVarP(&flagStage, "environment", "e", "", "Environment selection")
 }

--- a/pkg/varsub/source.go
+++ b/pkg/varsub/source.go
@@ -1,0 +1,35 @@
+package varsub
+
+// Source is a variable substitution source.
+type Source interface {
+	// Lookup tries to look up a value based on name and returns that value as
+	// well as true on success, or false if the variable was not found.
+	Lookup(name string) (interface{}, bool)
+}
+
+// SourceSlice is a slice of variable substution sources that act as a source
+// itself by returning the first successful lookup.
+type SourceSlice []Source
+
+// Lookup tries to look up a value based on name and returns that value as
+// well as true on success, or false if the variable was not found.
+func (ss SourceSlice) Lookup(name string) (interface{}, bool) {
+	for _, s := range ss {
+		val, ok := s.Lookup(name)
+		if ok {
+			return val, true
+		}
+	}
+	return nil, false
+}
+
+// SourceMap is a variable substitution source based on a map where it uses the
+// underlying map as the variable source.
+type SourceMap map[string]interface{}
+
+// Lookup tries to look up a value based on name and returns that value as
+// well as true on success, or false if the variable was not found.
+func (s SourceMap) Lookup(name string) (interface{}, bool) {
+	val, ok := s[name]
+	return val, ok
+}

--- a/pkg/varsub/varsub.go
+++ b/pkg/varsub/varsub.go
@@ -53,6 +53,7 @@ func substituteRec(source string, params map[string]interface{}, usedParams []st
 			}
 		}
 		if len(matches) == 1 && len(source) == len(match.FullMatch) {
+			// keep the value as-is if it matches the whole source
 			return anyValue, nil
 		}
 		strValue := stringify(anyValue)

--- a/pkg/varsub/varsub.go
+++ b/pkg/varsub/varsub.go
@@ -6,17 +6,19 @@ import (
 )
 
 type VarMatch struct {
-	Name   string
-	Syntax string
+	Name       string
+	FullMatch  string
+	StartIndex int
+	EndIndex   int
 }
 
-var varSyntaxPattern = regexp.MustCompile(`\${\s*(?P<paramName>%*[\w_\s]*%*)\s*}`)
-var paramNamePattern = regexp.MustCompile(`\s*(?P<cleanParamName>\w*[\s_]*\w+)\s*`)
-var escapedParamPattern = regexp.MustCompile(`%(?P<paramValue>\s*[\w_\s]*\s*)%`)
+var varSyntaxPattern = regexp.MustCompile(`\${\s*(%*[\w_\s]*%*)\s*}`)
+var paramNamePattern = regexp.MustCompile(`\s*(\w*[\s_]*\w+)\s*`)
+var escapedParamPattern = regexp.MustCompile(`%(\s*[\w_\s]*\s*)%`)
 
-func ReplaceVariables(source string, params map[string]interface{}) string {
+func Substitute(source string, params map[string]interface{}) string {
 	result := source
-	varMatches := GetVarMatches(source)
+	varMatches := Matches(source)
 
 	var newValue string
 	for _, match := range varMatches {
@@ -26,38 +28,41 @@ func ReplaceVariables(source string, params map[string]interface{}) string {
 			newValue = "${}"
 			ok = true
 		} else if escapedParamPattern.MatchString(match.Name) {
-			newValue = escapedParamPattern.ReplaceAllString(match.Name, "${$paramValue}")
+			newValue = escapedParamPattern.ReplaceAllString(match.Name, "${$1}")
 			ok = true
 		} else {
 			newValue, ok = params[match.Name].(string)
 		}
 
 		if ok {
-			result = strings.Replace(result, match.Syntax, newValue, -1)
+			result = strings.Replace(result, match.FullMatch, newValue, -1)
 		}
 	}
 
 	return result
 }
 
-func GetVarMatches(source string) []VarMatch {
-	matches := varSyntaxPattern.FindAllStringSubmatch(source, -1)
+func Matches(source string) []VarMatch {
+	matches := varSyntaxPattern.FindAllStringSubmatchIndex(source, -1)
 	var params []VarMatch
 
 	for _, match := range matches {
-		paramName := match[1]
+		start, end := match[2], match[3]
+		paramName := source[start:end]
 
 		if paramName == "" {
 			continue
 		}
 
 		if paramName[0] != '%' {
-			paramName = paramNamePattern.ReplaceAllString(paramName, "$cleanParamName")
+			paramName = paramNamePattern.ReplaceAllString(paramName, "$1")
 		}
 
 		params = append(params, VarMatch{
-			Name:   paramName,
-			Syntax: match[0],
+			Name:       paramName,
+			FullMatch:  source[match[0]:match[1]],
+			StartIndex: start,
+			EndIndex:   end,
 		})
 	}
 

--- a/pkg/varsub/varsub.go
+++ b/pkg/varsub/varsub.go
@@ -36,7 +36,7 @@ func Substitute(source string, params map[string]interface{}) interface{} {
 		if len(matches) == 1 && len(source) == len(match.FullMatch) {
 			return newValue
 		}
-		result = strings.Replace(result, match.FullMatch, stringify(newValue), -1)
+		result = strings.Replace(result, match.FullMatch, stringify(newValue), 1)
 	}
 	return result
 }

--- a/pkg/varsub/varsub.go
+++ b/pkg/varsub/varsub.go
@@ -45,7 +45,7 @@ func stringify(val interface{}) string {
 	switch val := val.(type) {
 	case string:
 		return val
-	case nil:
+	case nil: // fmt.Sprint returns "<nil>"; we don't want that
 		return ""
 	default:
 		return fmt.Sprint(val)

--- a/pkg/varsub/varsub_test.go
+++ b/pkg/varsub/varsub_test.go
@@ -13,73 +13,73 @@ func TestMatches(t *testing.T) {
 		FullMatch string
 	}
 	tests := []struct {
-		name   string
-		source string
-		want   []testMatch
+		name  string
+		value string
+		want  []testMatch
 	}{
 		{
-			name:   "text without variable",
-			source: "text without variable",
-			want:   nil,
+			name:  "text without variable",
+			value: "text without variable",
+			want:  nil,
 		},
 		{
-			name:   "simple variable",
-			source: "${lorem}",
-			want:   []testMatch{{Name: "lorem", FullMatch: "${lorem}"}},
+			name:  "simple variable",
+			value: "${lorem}",
+			want:  []testMatch{{Name: "lorem", FullMatch: "${lorem}"}},
 		},
 		{
-			name:   "invalid simple variable",
-			source: "${lorem ipsum}",
-			want:   []testMatch{{Name: "lorem ipsum", FullMatch: "${lorem ipsum}"}},
+			name:  "invalid simple variable",
+			value: "${lorem ipsum}",
+			want:  []testMatch{{Name: "lorem ipsum", FullMatch: "${lorem ipsum}"}},
 		},
 		{
-			name:   "simple text with variable",
-			source: "Foo ${lorem} bar",
-			want:   []testMatch{{Name: "lorem", FullMatch: "${lorem}"}},
+			name:  "simple text with variable",
+			value: "Foo ${lorem} bar",
+			want:  []testMatch{{Name: "lorem", FullMatch: "${lorem}"}},
 		},
 		{
-			name:   "simple text with variable and white spaces",
-			source: "Foo ${\n \tlorem\r} bar",
-			want:   []testMatch{{Name: "lorem", FullMatch: "${\n \tlorem\r}"}},
+			name:  "simple text with variable and white spaces",
+			value: "Foo ${\n \tlorem\r} bar",
+			want:  []testMatch{{Name: "lorem", FullMatch: "${\n \tlorem\r}"}},
 		},
 		{
-			name:   "simple text with escaped variable",
-			source: "Foo ${%lorem%} bar",
-			want:   []testMatch{{Name: "%lorem%", FullMatch: "${%lorem%}"}},
+			name:  "simple text with escaped variable",
+			value: "Foo ${%lorem%} bar",
+			want:  []testMatch{{Name: "%lorem%", FullMatch: "${%lorem%}"}},
 		},
 		{
-			name:   "simple text with escaped empty string",
-			source: "Foo ${%%} bar",
-			want:   []testMatch{{Name: "%%", FullMatch: "${%%}"}},
+			name:  "simple text with escaped empty string",
+			value: "Foo ${%%} bar",
+			want:  []testMatch{{Name: "%%", FullMatch: "${%%}"}},
 		},
 		{
-			name:   "simple text with escaped empty string by singular percent",
-			source: "Foo ${%} bar",
-			want:   []testMatch{{Name: "%", FullMatch: "${%}"}},
+			name:  "simple text with escaped empty string by singular percent",
+			value: "Foo ${%} bar",
+			want:  []testMatch{{Name: "%", FullMatch: "${%}"}},
 		},
 		{
-			name:   "simple text with escaped white signs",
-			source: "Foo ${%\n \r%} bar",
-			want:   []testMatch{{Name: "%\n \r%", FullMatch: "${%\n \r%}"}},
+			name:  "simple text with escaped white signs",
+			value: "Foo ${%\n \r%} bar",
+			want:  []testMatch{{Name: "%\n \r%", FullMatch: "${%\n \r%}"}},
 		},
 		{
-			name:   "simple text with escaped white signs 2",
-			source: "Foo ${\t%\n \r% } bar",
-			want:   []testMatch{{Name: "%\n \r%", FullMatch: "${\t%\n \r% }"}},
+			name:  "simple text with escaped white signs 2",
+			value: "Foo ${\t%\n \r% } bar",
+			want:  []testMatch{{Name: "%\n \r%", FullMatch: "${\t%\n \r% }"}},
 		},
 		{
-			name:   "simple text with invalid escaped text",
-			source: "Foo ${%lorem} bar",
-			want:   []testMatch{{Name: "%lorem", FullMatch: "${%lorem}"}},
+			name:  "simple text with invalid escaped text",
+			value: "Foo ${%lorem} bar",
+			want:  []testMatch{{Name: "%lorem", FullMatch: "${%lorem}"}},
 		},
 		{
-			name:   "simple text with invalid variable",
-			source: "Foo ${} bar",
-			want:   nil,
+			name:  "simple text with invalid variable",
+			value: "Foo ${} bar",
+			want:  nil,
 		},
 		{
-			name:   "three variables",
-			source: "${lorem} ${ipsum} ${dolor}",
+			name:  "three variables",
+			value: "${lorem} ${ipsum} ${dolor}",
 			want: []testMatch{
 				{Name: "lorem", FullMatch: "${lorem}"},
 				{Name: "ipsum", FullMatch: "${ipsum}"},
@@ -90,7 +90,7 @@ func TestMatches(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			matches := Matches(tc.source)
+			matches := Matches(tc.value)
 			if len(tc.want) == 0 {
 				assert.Len(t, matches, 0)
 				return
@@ -105,74 +105,74 @@ func TestMatches(t *testing.T) {
 }
 
 func TestSubstitute(t *testing.T) {
-	vars := map[string]interface{}{
+	source := SourceMap{
 		"lorem": "ipsum",
 	}
 	tests := []struct {
-		name   string
-		source string
-		want   string
+		name  string
+		value string
+		want  string
 	}{
 		{
-			name:   "simple variable",
-			source: "${lorem}",
-			want:   "ipsum",
+			name:  "simple variable",
+			value: "${lorem}",
+			want:  "ipsum",
 		},
 		{
-			name:   "invalid simple variable",
-			source: "${lorem ipsum}",
-			want:   "${lorem ipsum}",
+			name:  "invalid simple variable",
+			value: "${lorem ipsum}",
+			want:  "${lorem ipsum}",
 		},
 		{
-			name:   "simple text with variable",
-			source: "Foo ${lorem} bar",
-			want:   "Foo ipsum bar",
+			name:  "simple text with variable",
+			value: "Foo ${lorem} bar",
+			want:  "Foo ipsum bar",
 		},
 		{
-			name:   "simple text with variable and white spaces",
-			source: "Foo ${\n \tlorem\r} bar",
-			want:   "Foo ipsum bar",
+			name:  "simple text with variable and white spaces",
+			value: "Foo ${\n \tlorem\r} bar",
+			want:  "Foo ipsum bar",
 		},
 		{
-			name:   "simple text with escaped variable",
-			source: "Foo ${%lorem%} bar",
-			want:   "Foo ${lorem} bar",
+			name:  "simple text with escaped variable",
+			value: "Foo ${%lorem%} bar",
+			want:  "Foo ${lorem} bar",
 		},
 		{
-			name:   "simple text with escaped empty string",
-			source: "Foo ${%%} bar",
-			want:   "Foo ${} bar",
+			name:  "simple text with escaped empty string",
+			value: "Foo ${%%} bar",
+			want:  "Foo ${} bar",
 		},
 		{
-			name:   "simple text with escaped empty string by singular percent",
-			source: "Foo ${%} bar",
-			want:   "Foo ${} bar",
+			name:  "simple text with escaped empty string by singular percent",
+			value: "Foo ${%} bar",
+			want:  "Foo ${} bar",
 		},
 		{
-			name:   "simple text with escaped empty white signs",
-			source: "Foo ${%\n \r%} bar",
-			want:   "Foo ${\n \r} bar",
+			name:  "simple text with escaped empty white signs",
+			value: "Foo ${%\n \r%} bar",
+			want:  "Foo ${\n \r} bar",
 		},
 		{
-			name:   "simple text with escaped empty white signs 2",
-			source: "Foo ${ %\n \r%\n} bar",
-			want:   "Foo ${\n \r} bar",
+			name:  "simple text with escaped empty white signs 2",
+			value: "Foo ${ %\n \r%\n} bar",
+			want:  "Foo ${\n \r} bar",
 		},
 		{
-			name:   "simple text with invalid escaped text",
-			source: "Foo ${%lorem} bar",
-			want:   "Foo ${%lorem} bar",
+			name:  "simple text with invalid escaped text",
+			value: "Foo ${%lorem} bar",
+			want:  "Foo ${%lorem} bar",
 		},
 		{
-			name:   "simple text with invalid variable",
-			source: "Foo ${} bar",
-			want:   "Foo ${} bar",
+			name:  "simple text with invalid variable",
+			value: "Foo ${} bar",
+			want:  "Foo ${} bar",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := Substitute(tc.source, vars)
+			got, err := Substitute(tc.value, source)
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, got)
 		})
@@ -182,63 +182,63 @@ func TestSubstitute(t *testing.T) {
 func TestSubstitute_nonStrings(t *testing.T) {
 	tests := []struct {
 		name   string
-		vars   map[string]interface{}
-		source string
+		source SourceMap
+		value  string
 		want   interface{}
 	}{
 		{
 			name:   "full/bool",
-			vars:   map[string]interface{}{"lorem": true},
-			source: "${lorem}",
+			source: SourceMap{"lorem": true},
+			value:  "${lorem}",
 			want:   true,
 		},
 		{
 			name:   "full/int",
-			vars:   map[string]interface{}{"lorem": 123},
-			source: "${lorem}",
+			source: SourceMap{"lorem": 123},
+			value:  "${lorem}",
 			want:   123,
 		},
 		{
 			name:   "full/float",
-			vars:   map[string]interface{}{"lorem": 123.0},
-			source: "${lorem}",
+			source: SourceMap{"lorem": 123.0},
+			value:  "${lorem}",
 			want:   123.0,
 		},
 		{
 			name:   "full/nil",
-			vars:   map[string]interface{}{"lorem": nil},
-			source: "${lorem}",
+			source: SourceMap{"lorem": nil},
+			value:  "${lorem}",
 			want:   nil,
 		},
 		{
 			name:   "embed/bool",
-			vars:   map[string]interface{}{"lorem": true},
-			source: "foo ${lorem} bar",
+			source: SourceMap{"lorem": true},
+			value:  "foo ${lorem} bar",
 			want:   "foo true bar",
 		},
 		{
 			name:   "embed/int",
-			vars:   map[string]interface{}{"lorem": 123},
-			source: "foo ${lorem} bar",
+			source: SourceMap{"lorem": 123},
+			value:  "foo ${lorem} bar",
 			want:   "foo 123 bar",
 		},
 		{
 			name:   "embed/float",
-			vars:   map[string]interface{}{"lorem": 123.0},
-			source: "foo ${lorem} bar",
+			source: SourceMap{"lorem": 123.0},
+			value:  "foo ${lorem} bar",
 			want:   "foo 123 bar",
 		},
 		{
 			name:   "embed/nil",
-			vars:   map[string]interface{}{"lorem": nil},
-			source: "foo ${lorem} bar",
+			source: SourceMap{"lorem": nil},
+			value:  "foo ${lorem} bar",
 			want:   "foo  bar",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := Substitute(tc.source, tc.vars)
+			got, err := Substitute(tc.value, tc.source)
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, got)
 		})
@@ -248,33 +248,33 @@ func TestSubstitute_nonStrings(t *testing.T) {
 func TestSubstitute_recursive(t *testing.T) {
 	tests := []struct {
 		name   string
-		vars   map[string]interface{}
-		source string
+		source SourceMap
+		value  string
 		want   interface{}
 	}{
 		{
 			name: "string",
-			vars: map[string]interface{}{
+			source: SourceMap{
 				"one": "11${two}11",
 				"two": 2222,
 			},
-			source: "00${one}00",
-			want:   "001122221100",
+			value: "00${one}00",
+			want:  "001122221100",
 		},
 		{
 			name: "typed",
-			vars: map[string]interface{}{
+			source: SourceMap{
 				"one": "${two}",
 				"two": 2222,
 			},
-			source: "${one}",
-			want:   2222,
+			value: "${one}",
+			want:  2222,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := Substitute(tc.source, tc.vars)
+			got, err := Substitute(tc.value, tc.source)
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, got)
 		})
@@ -282,9 +282,9 @@ func TestSubstitute_recursive(t *testing.T) {
 }
 
 func TestSubstitute_errIfRecursiveLoop(t *testing.T) {
-	vars := map[string]interface{}{
+	source := SourceMap{
 		"lorem": "ipsum: ${lorem}",
 	}
-	result, err := Substitute("root: ${lorem}", vars)
+	result, err := Substitute("root: ${lorem}", source)
 	assert.ErrorIsf(t, err, ErrRecursiveLoop, "unexpected result: %q", result)
 }

--- a/pkg/varsub/varsub_test.go
+++ b/pkg/varsub/varsub_test.go
@@ -1,170 +1,177 @@
 package varsub
 
 import (
-	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetListOfParamsNames(t *testing.T) {
-	type testCase struct {
-		name           string
-		source         string
-		expectedResult []VarMatch
+func TestMatches(t *testing.T) {
+	type testMatch struct {
+		Name      string
+		FullMatch string
 	}
-
-	tests := []testCase{
+	tests := []struct {
+		name   string
+		source string
+		want   []testMatch
+	}{
 		{
-			name:           "text without variable",
-			source:         "text without variable",
-			expectedResult: nil,
+			name:   "text without variable",
+			source: "text without variable",
+			want:   nil,
 		},
 		{
-			name:           "simple variable",
-			source:         "${lorem}",
-			expectedResult: []VarMatch{{Name: "lorem", Syntax: "${lorem}"}},
+			name:   "simple variable",
+			source: "${lorem}",
+			want:   []testMatch{{Name: "lorem", FullMatch: "${lorem}"}},
 		},
 		{
-			name:           "invalid simple variable",
-			source:         "${lorem ipsum}",
-			expectedResult: []VarMatch{{Name: "lorem ipsum", Syntax: "${lorem ipsum}"}},
+			name:   "invalid simple variable",
+			source: "${lorem ipsum}",
+			want:   []testMatch{{Name: "lorem ipsum", FullMatch: "${lorem ipsum}"}},
 		},
 		{
-			name:           "simple text with variable",
-			source:         "Foo ${lorem} bar",
-			expectedResult: []VarMatch{{Name: "lorem", Syntax: "${lorem}"}},
+			name:   "simple text with variable",
+			source: "Foo ${lorem} bar",
+			want:   []testMatch{{Name: "lorem", FullMatch: "${lorem}"}},
 		},
 		{
-			name:           "simple text with variable and white spaces",
-			source:         "Foo ${\n \tlorem\r} bar",
-			expectedResult: []VarMatch{{Name: "lorem", Syntax: "${\n \tlorem\r}"}},
+			name:   "simple text with variable and white spaces",
+			source: "Foo ${\n \tlorem\r} bar",
+			want:   []testMatch{{Name: "lorem", FullMatch: "${\n \tlorem\r}"}},
 		},
 		{
-			name:           "simple text with escaped variable",
-			source:         "Foo ${%lorem%} bar",
-			expectedResult: []VarMatch{{Name: "%lorem%", Syntax: "${%lorem%}"}},
+			name:   "simple text with escaped variable",
+			source: "Foo ${%lorem%} bar",
+			want:   []testMatch{{Name: "%lorem%", FullMatch: "${%lorem%}"}},
 		},
 		{
-			name:           "simple text with escaped empty string",
-			source:         "Foo ${%%} bar",
-			expectedResult: []VarMatch{{Name: "%%", Syntax: "${%%}"}},
+			name:   "simple text with escaped empty string",
+			source: "Foo ${%%} bar",
+			want:   []testMatch{{Name: "%%", FullMatch: "${%%}"}},
 		},
 		{
-			name:           "simple text with escaped empty string by singular percent",
-			source:         "Foo ${%} bar",
-			expectedResult: []VarMatch{{Name: "%", Syntax: "${%}"}},
+			name:   "simple text with escaped empty string by singular percent",
+			source: "Foo ${%} bar",
+			want:   []testMatch{{Name: "%", FullMatch: "${%}"}},
 		},
 		{
-			name:           "simple text with escaped white signs",
-			source:         "Foo ${%\n \r%} bar",
-			expectedResult: []VarMatch{{Name: "%\n \r%", Syntax: "${%\n \r%}"}},
+			name:   "simple text with escaped white signs",
+			source: "Foo ${%\n \r%} bar",
+			want:   []testMatch{{Name: "%\n \r%", FullMatch: "${%\n \r%}"}},
 		},
 		{
-			name:           "simple text with escaped white signs 2",
-			source:         "Foo ${\t%\n \r% } bar",
-			expectedResult: []VarMatch{{Name: "%\n \r%", Syntax: "${\t%\n \r% }"}},
+			name:   "simple text with escaped white signs 2",
+			source: "Foo ${\t%\n \r% } bar",
+			want:   []testMatch{{Name: "%\n \r%", FullMatch: "${\t%\n \r% }"}},
 		},
 		{
-			name:           "simple text with invalid escaped text",
-			source:         "Foo ${%lorem} bar",
-			expectedResult: []VarMatch{{Name: "%lorem", Syntax: "${%lorem}"}},
+			name:   "simple text with invalid escaped text",
+			source: "Foo ${%lorem} bar",
+			want:   []testMatch{{Name: "%lorem", FullMatch: "${%lorem}"}},
 		},
 		{
-			name:           "simple text with invalid variable",
-			source:         "Foo ${} bar",
-			expectedResult: nil,
+			name:   "simple text with invalid variable",
+			source: "Foo ${} bar",
+			want:   nil,
 		},
 		{
 			name:   "three variables",
 			source: "${lorem} ${ipsum} ${dolor}",
-			expectedResult: []VarMatch{
-				{Name: "lorem", Syntax: "${lorem}"},
-				{Name: "ipsum", Syntax: "${ipsum}"},
-				{Name: "dolor", Syntax: "${dolor}"},
+			want: []testMatch{
+				{Name: "lorem", FullMatch: "${lorem}"},
+				{Name: "ipsum", FullMatch: "${ipsum}"},
+				{Name: "dolor", FullMatch: "${dolor}"},
 			},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := GetVarMatches(tc.source)
-			eq := reflect.DeepEqual(tc.expectedResult, result)
-			assert.True(t, eq, fmt.Sprintf("should be: %v, got: %v", tc.expectedResult, result))
+			matches := Matches(tc.source)
+			if len(tc.want) == 0 {
+				assert.Len(t, matches, 0)
+				return
+			}
+			got := make([]testMatch, len(matches))
+			for i, m := range matches {
+				got[i] = testMatch{Name: m.Name, FullMatch: m.FullMatch}
+			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }
 
-func TestReplaceVariables(t *testing.T) {
-	type testCase struct {
-		name           string
-		source         string
-		expectedResult string
-	}
-
-	tests := []testCase{
+func TestSubstitute(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
 		{
-			name:           "simple variable",
-			source:         "${lorem}",
-			expectedResult: "ipsum",
+			name:   "simple variable",
+			source: "${lorem}",
+			want:   "ipsum",
 		},
 		{
-			name:           "invalid simple variable",
-			source:         "${lorem ipsum}",
-			expectedResult: "${lorem ipsum}",
+			name:   "invalid simple variable",
+			source: "${lorem ipsum}",
+			want:   "${lorem ipsum}",
 		},
 		{
-			name:           "simple text with variable",
-			source:         "Foo ${lorem} bar",
-			expectedResult: "Foo ipsum bar",
+			name:   "simple text with variable",
+			source: "Foo ${lorem} bar",
+			want:   "Foo ipsum bar",
 		},
 		{
-			name:           "simple text with variable and white spaces",
-			source:         "Foo ${\n \tlorem\r} bar",
-			expectedResult: "Foo ipsum bar",
+			name:   "simple text with variable and white spaces",
+			source: "Foo ${\n \tlorem\r} bar",
+			want:   "Foo ipsum bar",
 		},
 		{
-			name:           "simple text with escaped variable",
-			source:         "Foo ${%lorem%} bar",
-			expectedResult: "Foo ${lorem} bar",
+			name:   "simple text with escaped variable",
+			source: "Foo ${%lorem%} bar",
+			want:   "Foo ${lorem} bar",
 		},
 		{
-			name:           "simple text with escaped empty string",
-			source:         "Foo ${%%} bar",
-			expectedResult: "Foo ${} bar",
+			name:   "simple text with escaped empty string",
+			source: "Foo ${%%} bar",
+			want:   "Foo ${} bar",
 		},
 		{
-			name:           "simple text with escaped empty string by singular percent",
-			source:         "Foo ${%} bar",
-			expectedResult: "Foo ${} bar",
+			name:   "simple text with escaped empty string by singular percent",
+			source: "Foo ${%} bar",
+			want:   "Foo ${} bar",
 		},
 		{
-			name:           "simple text with escaped empty white signs",
-			source:         "Foo ${%\n \r%} bar",
-			expectedResult: "Foo ${\n \r} bar",
+			name:   "simple text with escaped empty white signs",
+			source: "Foo ${%\n \r%} bar",
+			want:   "Foo ${\n \r} bar",
 		},
 		{
-			name:           "simple text with escaped empty white signs 2",
-			source:         "Foo ${ %\n \r%\n} bar",
-			expectedResult: "Foo ${\n \r} bar",
+			name:   "simple text with escaped empty white signs 2",
+			source: "Foo ${ %\n \r%\n} bar",
+			want:   "Foo ${\n \r} bar",
 		},
 		{
-			name:           "simple text with invalid escaped text",
-			source:         "Foo ${%lorem} bar",
-			expectedResult: "Foo ${%lorem} bar",
+			name:   "simple text with invalid escaped text",
+			source: "Foo ${%lorem} bar",
+			want:   "Foo ${%lorem} bar",
 		},
 		{
-			name:           "simple text with invalid variable",
-			source:         "Foo ${} bar",
-			expectedResult: "Foo ${} bar",
+			name:   "simple text with invalid variable",
+			source: "Foo ${} bar",
+			want:   "Foo ${} bar",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := ReplaceVariables(tc.source, map[string]interface{}{"lorem": "ipsum"})
-			assert.Equal(t, tc.expectedResult, result)
+			got := Substitute(tc.source, map[string]interface{}{
+				"lorem": "ipsum",
+			})
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/pkg/varsub/varsub_test.go
+++ b/pkg/varsub/varsub_test.go
@@ -104,6 +104,9 @@ func TestMatches(t *testing.T) {
 }
 
 func TestSubstitute(t *testing.T) {
+	vars := map[string]interface{}{
+		"lorem": "ipsum",
+	}
 	tests := []struct {
 		name   string
 		source string
@@ -168,9 +171,72 @@ func TestSubstitute(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := Substitute(tc.source, map[string]interface{}{
-				"lorem": "ipsum",
-			})
+			got := Substitute(tc.source, vars)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestSubstitute_nonStrings(t *testing.T) {
+	tests := []struct {
+		name   string
+		vars   map[string]interface{}
+		source string
+		want   interface{}
+	}{
+		{
+			name:   "full/bool",
+			vars:   map[string]interface{}{"lorem": true},
+			source: "${lorem}",
+			want:   true,
+		},
+		{
+			name:   "full/int",
+			vars:   map[string]interface{}{"lorem": 123},
+			source: "${lorem}",
+			want:   123,
+		},
+		{
+			name:   "full/float",
+			vars:   map[string]interface{}{"lorem": 123.0},
+			source: "${lorem}",
+			want:   123.0,
+		},
+		{
+			name:   "full/nil",
+			vars:   map[string]interface{}{"lorem": nil},
+			source: "${lorem}",
+			want:   nil,
+		},
+		{
+			name:   "embed/bool",
+			vars:   map[string]interface{}{"lorem": true},
+			source: "foo ${lorem} bar",
+			want:   "foo true bar",
+		},
+		{
+			name:   "embed/int",
+			vars:   map[string]interface{}{"lorem": 123},
+			source: "foo ${lorem} bar",
+			want:   "foo 123 bar",
+		},
+		{
+			name:   "embed/float",
+			vars:   map[string]interface{}{"lorem": 123.0},
+			source: "foo ${lorem} bar",
+			want:   "foo 123 bar",
+		},
+		{
+			name:   "embed/nil",
+			vars:   map[string]interface{}{"lorem": nil},
+			source: "foo ${lorem} bar",
+			want:   "foo  bar",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Substitute(tc.source, tc.vars)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/pkg/wharfyml/definition.go
+++ b/pkg/wharfyml/definition.go
@@ -58,6 +58,8 @@ func visitDefNode(node *yaml.Node, args Args) (def Definition, errSlice Errors) 
 	def.Stages = stages
 	errSlice.add(errs...)
 	errSlice.add(validateDefEnvironmentUsage(def)...)
+	// filtering intentionally performed after validation
+	def.Stages = filterStagesOnEnv(def.Stages, args.Env)
 	return
 }
 
@@ -104,4 +106,26 @@ func validateDefEnvironmentUsage(def Definition) Errors {
 		}
 	}
 	return errSlice
+}
+
+func filterStagesOnEnv(stages []Stage, envFilter string) []Stage {
+	var filtered []Stage
+	for _, stage := range stages {
+		if containsEnvFilter(stage.Envs, envFilter) {
+			filtered = append(filtered, stage)
+		}
+	}
+	return filtered
+}
+
+func containsEnvFilter(envRefs []EnvRef, envFilter string) bool {
+	if envFilter == "" && len(envRefs) == 0 {
+		return true
+	}
+	for _, ref := range envRefs {
+		if ref.Name == envFilter {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/wharfyml/definition.go
+++ b/pkg/wharfyml/definition.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/iver-wharf/wharf-cmd/pkg/varsub"
 	"gopkg.in/yaml.v3"
 )
 
@@ -16,29 +17,77 @@ var (
 type Definition struct {
 	Inputs map[string]Input
 	Envs   map[string]Env
+	Env    *Env
 	Stages []Stage
 }
 
-func visitDefNode(node *yaml.Node) (def Definition, errSlice Errors) {
+func visitDefNode(node *yaml.Node, args Args) (def Definition, errSlice Errors) {
 	nodes, errs := visitMapSlice(node)
 	errSlice.add(errs...)
+	envSourceNode := node
 	for _, n := range nodes {
 		switch n.key.value {
 		case propEnvironments:
 			var errs Errors
 			def.Envs, errs = visitDocEnvironmentsNode(n.value)
 			errSlice.add(wrapPathErrorSlice(errs, propEnvironments)...)
+			envSourceNode = n.value
 		case propInputs:
 			var errs Errors
 			def.Inputs, errs = visitInputsNode(n.value)
 			errSlice.add(wrapPathErrorSlice(errs, propInputs)...)
-		default:
-			stage, errs := visitStageNode(n.key, n.value)
-			def.Stages = append(def.Stages, stage)
-			errSlice.add(wrapPathErrorSlice(errs, n.key.value)...)
 		}
 	}
+
+	var sources varsub.SourceSlice
+	if args.VarSource != nil {
+		sources = append(sources, args.VarSource)
+	}
+
+	targetEnv, err := getTargetEnv(def.Envs, args.Env)
+	if err != nil {
+		err = wrapPosErrorNode(err, envSourceNode)
+		err = wrapPathError(err, propEnvironments)
+		errSlice.add(err) // Non fatal error
+	} else if targetEnv != nil {
+		def.Env = targetEnv
+		sources = append(sources, varsub.SourceMap(targetEnv.Vars))
+	}
+
+	stages, errs := visitDefStageNodes(nodes, sources)
+	def.Stages = stages
+	errSlice.add(errs...)
 	errSlice.add(validateDefEnvironmentUsage(def)...)
+	return
+}
+
+func getTargetEnv(envs map[string]Env, envName string) (*Env, error) {
+	if envName == "" {
+		return nil, nil
+	}
+	env, ok := envs[envName]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUseOfUndefinedEnv, envName)
+	}
+	return &env, nil
+}
+
+func visitDefStageNodes(nodes []mapItem, source varsub.Source) (stages []Stage, errSlice Errors) {
+	for _, n := range nodes {
+		switch n.key.value {
+		case propEnvironments, propInputs:
+			// Do nothing, they've already been visited.
+			continue
+		}
+		stageNode, err := varSubNodeRec(n.value, source)
+		if err != nil {
+			errSlice.add(err)
+			continue
+		}
+		stage, errs := visitStageNode(n.key, stageNode)
+		stages = append(stages, stage)
+		errSlice.add(wrapPathErrorSlice(errs, n.key.value)...)
+	}
 	return
 }
 

--- a/pkg/wharfyml/parse.go
+++ b/pkg/wharfyml/parse.go
@@ -8,29 +8,37 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/iver-wharf/wharf-cmd/pkg/varsub"
 	"gopkg.in/yaml.v3"
 )
 
+// Args specify arguments used when parsing the .wharf-ci.yml file, such as what
+// environment to use for variable substitution.
+type Args struct {
+	Env       string
+	VarSource varsub.Source
+}
+
 // ParseFile will parse the file at the given path.
 // Multiple errors may be returned, one for each validation or parsing error.
-func ParseFile(path string) (Definition, Errors) {
+func ParseFile(path string, args Args) (Definition, Errors) {
 	file, err := os.Open(path)
 	if err != nil {
 		return Definition{}, Errors{err}
 	}
 	defer file.Close()
-	return Parse(file)
+	return Parse(file, args)
 }
 
 // Parse will parse the YAML content as a .wharf-ci.yml definition structure.
 // Multiple errors may be returned, one for each validation or parsing error.
-func Parse(reader io.Reader) (def Definition, errSlice Errors) {
-	def, errs := parse(reader)
+func Parse(reader io.Reader, args Args) (def Definition, errSlice Errors) {
+	def, errs := parse(reader, args)
 	sortErrorsByPosition(errs)
 	return def, errs
 }
 
-func parse(reader io.Reader) (def Definition, errSlice Errors) {
+func parse(reader io.Reader, args Args) (def Definition, errSlice Errors) {
 	doc, err := decodeFirstDoc(reader)
 	if err != nil {
 		errSlice.add(err)
@@ -39,7 +47,7 @@ func parse(reader io.Reader) (def Definition, errSlice Errors) {
 		return
 	}
 	var errs Errors
-	def, errs = visitDefNode(doc)
+	def, errs = visitDefNode(doc, args)
 	errSlice.add(errs...)
 	return
 }
@@ -63,7 +71,18 @@ func decodeFirstDoc(reader io.Reader) (*yaml.Node, error) {
 		// Continue, but only parse the first doc
 		return body, ErrTooManyDocs
 	}
+	body = unwrapNodeRec(body)
 	return body, nil
+}
+
+func unwrapNodeRec(node *yaml.Node) *yaml.Node {
+	for node.Alias != nil {
+		node = node.Alias
+	}
+	for i, child := range node.Content {
+		node.Content[i] = unwrapNodeRec(child)
+	}
+	return node
 }
 
 func parseInt(str string) (int, error) {

--- a/pkg/wharfyml/parse_test.go
+++ b/pkg/wharfyml/parse_test.go
@@ -55,7 +55,7 @@ myStage2:
   myKubectlStep:
     kubectl:
       file: deploy/pod.yaml
-`))
+`), Args{})
 	requireNoErr(t, errs)
 
 	assert.Len(t, got.Inputs, 4)
@@ -137,7 +137,7 @@ environments:
   myEnv:
     myStr: !!str 123
     myInt: !!int 123
-`))
+`), Args{})
 	requireNoErr(t, errs)
 	myEnv, ok := def.Envs["myEnv"]
 	require.True(t, ok, "myEnv environment exists")
@@ -153,7 +153,7 @@ myStage1: &reused
     helm-package: {}
 
 myStage2: *reused
-`))
+`), Args{})
 	requireNoErr(t, errs)
 	require.Len(t, def.Stages, 2)
 	assert.Equal(t, "myStage1", def.Stages[0].Name, "stage 1 name")
@@ -175,7 +175,7 @@ myStage2:
   <<: *reused
   myOtherStep:
     helm-package: {}
-`))
+`), Args{})
 	requireNoErr(t, errs)
 	require.Len(t, def.Stages, 2)
 	assert.Equal(t, "myStage1", def.Stages[0].Name, "stage 1 name")
@@ -227,7 +227,7 @@ C:
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, errs := Parse(strings.NewReader(tc.input))
+			got, errs := Parse(strings.NewReader(tc.input), Args{})
 			require.Empty(t, errs)
 			var gotOrder []string
 			for _, s := range got.Stages {
@@ -273,7 +273,7 @@ myStage:
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, errs := Parse(strings.NewReader(tc.input))
+			got, errs := Parse(strings.NewReader(tc.input), Args{})
 			requireNoErr(t, errs)
 			require.Len(t, got.Stages, 1)
 			var gotOrder []string
@@ -292,7 +292,7 @@ a: 1
 b: 2
 ---
 c: 3
-`))
+`), Args{})
 	requireContainsErr(t, errs, ErrTooManyDocs)
 }
 
@@ -300,31 +300,31 @@ func TestParse_OneDocWithDocSeparator(t *testing.T) {
 	_, errs := Parse(strings.NewReader(`
 ---
 c: 3
-`))
+`), Args{})
 	requireNotContainsErr(t, errs, ErrTooManyDocs)
 }
 
 func TestParse_MissingDoc(t *testing.T) {
-	_, errs := Parse(strings.NewReader(``))
+	_, errs := Parse(strings.NewReader(``), Args{})
 	requireContainsErr(t, errs, ErrMissingDoc)
 }
 
 func TestParse_ErrIfDocNotMap(t *testing.T) {
-	_, errs := Parse(strings.NewReader(`123`))
+	_, errs := Parse(strings.NewReader(`123`), Args{})
 	requireContainsErr(t, errs, ErrInvalidFieldType)
 }
 
 func TestParse_ErrIfNonStringKey(t *testing.T) {
 	_, errs := Parse(strings.NewReader(`
 123: {}
-`))
+`), Args{})
 	requireContainsErr(t, errs, ErrKeyNotString)
 }
 
 func TestParse_ErrIfEmptyStageName(t *testing.T) {
 	_, errs := Parse(strings.NewReader(`
 "": {}
-`))
+`), Args{})
 	requireContainsErr(t, errs, ErrKeyEmpty)
 }
 
@@ -332,8 +332,56 @@ func TestParse_ErrIfUseOfUnknownEnv(t *testing.T) {
 	_, errs := Parse(strings.NewReader(`
 myStage:
   environments: [myEnv]
-`))
+`), Args{})
 	requireContainsErr(t, errs, ErrUseOfUndefinedEnv)
+}
+
+func TestParse_EnvVarSub(t *testing.T) {
+	const input = `
+environments:
+  myEnv:
+    myImage: ubuntu:latest
+    myCmd: echo hello world
+
+myStage:
+  myStep:
+    container:
+      image: ${myImage}
+      cmds:
+        - ${myCmd}
+`
+	testCases := []struct {
+		name      string
+		args      Args
+		wantImage string
+		wantCmd   string
+	}{
+		{
+			name:      "no env",
+			args:      Args{},
+			wantImage: "${myImage}",
+			wantCmd:   "${myCmd}",
+		},
+		{
+			name:      "with env",
+			args:      Args{Env: "myEnv"},
+			wantImage: "ubuntu:latest",
+			wantCmd:   "echo hello world",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			def, errs := Parse(strings.NewReader(input), tc.args)
+			require.Empty(t, errs)
+			require.Len(t, def.Stages, 1, "stage count")
+			require.Len(t, def.Stages[0].Steps, 1, "step count")
+			myStep, ok := def.Stages[0].Steps[0].Type.(StepContainer)
+			require.True(t, ok, "step type is container")
+
+			assert.Equal(t, tc.wantImage, myStep.Image, "container.image")
+			assert.Equal(t, []string{tc.wantCmd}, myStep.Cmds, "container.cmds")
+		})
+	}
 }
 
 func getKeyedNode(t *testing.T, content string) (strNode, *yaml.Node) {

--- a/pkg/wharfyml/varsub.go
+++ b/pkg/wharfyml/varsub.go
@@ -1,0 +1,83 @@
+package wharfyml
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/iver-wharf/wharf-cmd/pkg/varsub"
+	"gopkg.in/yaml.v3"
+)
+
+// Errors specific to performing variable substitution on nodes.
+var (
+	ErrUnsupportedVarSubType = errors.New("unsupported variable substitution value")
+)
+
+func varSubNodeRec(node *yaml.Node, source varsub.Source) (*yaml.Node, error) {
+	if source == nil {
+		return node, nil
+	}
+	if node.Kind == yaml.ScalarNode {
+		if node.Tag != shortTagString {
+			return node, nil
+		}
+		return varSubStringNode(strNode{node, node.Value}, source)
+	}
+	if len(node.Content) == 0 {
+		return node, nil
+	}
+	clone := *node
+	clone.Content = make([]*yaml.Node, len(node.Content))
+	for i, child := range node.Content {
+		child, err := varSubNodeRec(child, source)
+		if err != nil {
+			return nil, err
+		}
+		clone.Content[i] = child
+	}
+	return &clone, nil
+}
+
+func varSubStringNode(str strNode, source varsub.Source) (*yaml.Node, error) {
+	val, err := varsub.Substitute(str.value, source)
+	if err != nil {
+		return nil, wrapPosErrorNode(err, str.node)
+	}
+	return newNodeWithValue(str.node, val)
+}
+
+func newNodeWithValue(node *yaml.Node, val interface{}) (*yaml.Node, error) {
+	clone := *node
+	clone.Kind = yaml.ScalarNode
+	switch val := val.(type) {
+	case nil:
+		clone.Tag = shortTagNull
+		clone.Value = ""
+	case string:
+		clone.SetString(val)
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64:
+		clone.Tag = shortTagInt
+		clone.Value = fmt.Sprint(val)
+	case float32, float64:
+		clone.Tag = shortTagFloat
+		clone.Value = fmt.Sprint(val)
+	case time.Time:
+		clone.Tag = shortTagTimestamp
+		clone.Value = val.Format(time.RFC3339Nano)
+	case bool:
+		clone.Tag = shortTagBool
+		if val {
+			clone.Value = "true"
+		} else {
+			clone.Value = "false"
+		}
+	case *yaml.Node:
+		return val, nil
+	default:
+		err := fmt.Errorf("%w: %T", ErrUnsupportedVarSubType, val)
+		return nil, wrapPosErrorNode(err, node)
+	}
+	return &clone, nil
+}

--- a/pkg/wharfyml/visitor.go
+++ b/pkg/wharfyml/visitor.go
@@ -30,13 +30,6 @@ const (
 	shortTagMerge     = "!!merge"
 )
 
-func unwrapNode(node *yaml.Node) *yaml.Node {
-	for node.Alias != nil {
-		node = node.Alias
-	}
-	return node
-}
-
 func verifyKind(node *yaml.Node, wantStr string, wantKind yaml.Kind) error {
 	if node.Kind != wantKind {
 		return wrapPosErrorNode(fmt.Errorf("%w: expected %s, but was %s",
@@ -63,7 +56,6 @@ func verifyKindAndTag(node *yaml.Node, wantStr string, wantKind yaml.Kind, wantT
 
 func visitString(node *yaml.Node) (string, error) {
 	// TODO: Apply varsub
-	node = unwrapNode(node)
 	if err := verifyKindAndTag(node, "string", yaml.ScalarNode, shortTagString); err != nil {
 		return "", err
 	}
@@ -72,7 +64,6 @@ func visitString(node *yaml.Node) (string, error) {
 
 func visitInt(node *yaml.Node) (int, error) {
 	// TODO: Apply varsub
-	node = unwrapNode(node)
 	if err := verifyKindAndTag(node, "integer", yaml.ScalarNode, shortTagInt); err != nil {
 		return 0, err
 	}
@@ -85,7 +76,6 @@ func visitInt(node *yaml.Node) (int, error) {
 
 func visitFloat64(node *yaml.Node) (float64, error) {
 	// TODO: Apply varsub
-	node = unwrapNode(node)
 	if node.Kind == yaml.ScalarNode && node.ShortTag() == shortTagInt {
 		num, err := visitInt(node)
 		if err != nil {
@@ -105,7 +95,6 @@ func visitFloat64(node *yaml.Node) (float64, error) {
 
 func visitBool(node *yaml.Node) (bool, error) {
 	// TODO: Apply varsub
-	node = unwrapNode(node)
 	if err := verifyKindAndTag(node, "boolean", yaml.ScalarNode, shortTagBool); err != nil {
 		return false, err
 	}
@@ -136,7 +125,6 @@ type strNode struct {
 }
 
 func visitMapSlice(node *yaml.Node) ([]mapItem, Errors) {
-	node = unwrapNode(node)
 	var errSlice Errors
 
 	if err := verifyKind(node, "map", yaml.MappingNode); err != nil {
@@ -178,7 +166,6 @@ func visitMapSlice(node *yaml.Node) ([]mapItem, Errors) {
 }
 
 func visitSequence(node *yaml.Node) ([]*yaml.Node, error) {
-	node = unwrapNode(node)
 	if err := verifyKind(node, "sequence", yaml.SequenceNode); err != nil {
 		return nil, err
 	}

--- a/pkg/wharfyml/visitor.go
+++ b/pkg/wharfyml/visitor.go
@@ -62,6 +62,7 @@ func verifyKindAndTag(node *yaml.Node, wantStr string, wantKind yaml.Kind, wantT
 }
 
 func visitString(node *yaml.Node) (string, error) {
+	// TODO: Apply varsub
 	node = unwrapNode(node)
 	if err := verifyKindAndTag(node, "string", yaml.ScalarNode, shortTagString); err != nil {
 		return "", err
@@ -70,6 +71,7 @@ func visitString(node *yaml.Node) (string, error) {
 }
 
 func visitInt(node *yaml.Node) (int, error) {
+	// TODO: Apply varsub
 	node = unwrapNode(node)
 	if err := verifyKindAndTag(node, "integer", yaml.ScalarNode, shortTagInt); err != nil {
 		return 0, err
@@ -82,6 +84,7 @@ func visitInt(node *yaml.Node) (int, error) {
 }
 
 func visitFloat64(node *yaml.Node) (float64, error) {
+	// TODO: Apply varsub
 	node = unwrapNode(node)
 	if node.Kind == yaml.ScalarNode && node.ShortTag() == shortTagInt {
 		num, err := visitInt(node)
@@ -101,6 +104,7 @@ func visitFloat64(node *yaml.Node) (float64, error) {
 }
 
 func visitBool(node *yaml.Node) (bool, error) {
+	// TODO: Apply varsub
 	node = unwrapNode(node)
 	if err := verifyKindAndTag(node, "boolean", yaml.ScalarNode, shortTagBool); err != nil {
 		return false, err

--- a/pkg/wharfyml/visitor.go
+++ b/pkg/wharfyml/visitor.go
@@ -55,7 +55,6 @@ func verifyKindAndTag(node *yaml.Node, wantStr string, wantKind yaml.Kind, wantT
 }
 
 func visitString(node *yaml.Node) (string, error) {
-	// TODO: Apply varsub
 	if err := verifyKindAndTag(node, "string", yaml.ScalarNode, shortTagString); err != nil {
 		return "", err
 	}
@@ -63,7 +62,6 @@ func visitString(node *yaml.Node) (string, error) {
 }
 
 func visitInt(node *yaml.Node) (int, error) {
-	// TODO: Apply varsub
 	if err := verifyKindAndTag(node, "integer", yaml.ScalarNode, shortTagInt); err != nil {
 		return 0, err
 	}
@@ -75,7 +73,6 @@ func visitInt(node *yaml.Node) (int, error) {
 }
 
 func visitFloat64(node *yaml.Node) (float64, error) {
-	// TODO: Apply varsub
 	if node.Kind == yaml.ScalarNode && node.ShortTag() == shortTagInt {
 		num, err := visitInt(node)
 		if err != nil {
@@ -94,7 +91,6 @@ func visitFloat64(node *yaml.Node) (float64, error) {
 }
 
 func visitBool(node *yaml.Node) (bool, error) {
-	// TODO: Apply varsub
 	if err := verifyKindAndTag(node, "boolean", yaml.ScalarNode, shortTagBool); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added support for variable substituting non-string values
- Added support for recursive variable substitution
- Added support for environment variables substitution in `.wharf-ci.yml`
- Added stage filtering based on environment argument
- Added `--environment`, `-e` flag to `wharf-cmd run`

## Motivation

Closes #54
