### PR TITLE
Step runner factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
     wharf-cmd-workers from the wharf-cmd-provisioner and kills them in an effort
     to clean up forgotten builds/workers.
 
-- Added new implementation for `wharf run`. (#33, #45)
+- Added new implementation for `wharf run`. (#33, #45, #66)
 
 - Added new implementation for `.wharf-ci.yml` file parsing that now supports
   returning multiple errors for the whole parsing as well as keep track of the

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -53,14 +53,14 @@ https://iver-wharf.github.io/#/usage-wharfyml/
 			}
 			return errors.New("failed to parse .wharf-ci.yml")
 		}
-		log.Info().Message("PARSED .wharf-ci.yml")
+		log.Info().Message("Successfully parsed .wharf-ci.yml")
 		b, err := worker.NewK8s(context.Background(), def, ns, kubeconfig, worker.BuildOptions{
 			StageFilter: runFlags.stage,
 		})
 		if err != nil {
 			return err
 		}
-		log.Info().Message("CREATED WORKER")
+		log.Debug().Message("Successfully created builder. Starting build.")
 		res, err := b.Build(context.Background())
 		if err != nil {
 			return err

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -53,14 +53,15 @@ https://iver-wharf.github.io/#/usage-wharfyml/
 			}
 			return errors.New("failed to parse .wharf-ci.yml")
 		}
-		log.Info().Message("Successfully parsed .wharf-ci.yml")
+		log.Debug().Message("Successfully parsed .wharf-ci.yml")
 		b, err := worker.NewK8s(context.Background(), def, ns, kubeconfig, worker.BuildOptions{
 			StageFilter: runFlags.stage,
 		})
 		if err != nil {
 			return err
 		}
-		log.Debug().Message("Successfully created builder. Starting build.")
+		log.Debug().Message("Successfully created builder.")
+		log.Info().Message("Starting build.")
 		res, err := b.Build(context.Background())
 		if err != nil {
 			return err

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -37,12 +37,6 @@ https://iver-wharf.github.io/#/usage-wharfyml/
 		if err != nil {
 			return err
 		}
-		stepRun, err := worker.NewK8sStepRunner(ns, kubeconfig)
-		if err != nil {
-			return err
-		}
-		stageRun := worker.NewStageRunner(stepRun)
-		b := worker.New(stageRun)
 		def, errs := wharfyml.ParseFile(runFlags.path, wharfyml.Args{
 			Env: runFlags.env,
 		})
@@ -59,9 +53,15 @@ https://iver-wharf.github.io/#/usage-wharfyml/
 			}
 			return errors.New("failed to parse .wharf-ci.yml")
 		}
-		res, err := b.Build(context.Background(), def, worker.BuildOptions{
+		log.Info().Message("PARSED .wharf-ci.yml")
+		b, err := worker.NewK8s(context.Background(), def, ns, kubeconfig, worker.BuildOptions{
 			StageFilter: runFlags.stage,
 		})
+		if err != nil {
+			return err
+		}
+		log.Info().Message("CREATED WORKER")
+		res, err := b.Build(context.Background())
 		if err != nil {
 			return err
 		}

--- a/pkg/worker/builder.go
+++ b/pkg/worker/builder.go
@@ -10,13 +10,14 @@ import (
 )
 
 type builder struct {
+	opts         BuildOptions
 	def          wharfyml.Definition
 	stageRunners []StageRunner
 }
 
 // New returns a new Builder implementation that uses the provided StageRunner
 // to run all build stages in series.
-func New(ctx context.Context, stageRunFactory StageRunnerFactory, def wharfyml.Definition) (Builder, error) {
+func New(ctx context.Context, stageRunFactory StageRunnerFactory, def wharfyml.Definition, opts BuildOptions) (Builder, error) {
 	stageRunners := make([]StageRunner, len(def.Stages))
 	for i, stage := range def.Stages {
 		r, err := stageRunFactory.NewStageRunner(ctx, stage)
@@ -28,6 +29,10 @@ func New(ctx context.Context, stageRunFactory StageRunnerFactory, def wharfyml.D
 	return builder{
 		stageRunners: stageRunners,
 	}, nil
+}
+
+func (b builder) BuildOptions() BuildOptions {
+	return b.opts
 }
 
 func (b builder) Definition() wharfyml.Definition {

--- a/pkg/worker/builder.go
+++ b/pkg/worker/builder.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -9,22 +10,34 @@ import (
 )
 
 type builder struct {
-	stageRun StageRunner
+	def          wharfyml.Definition
+	stageRunners []StageRunner
 }
 
 // New returns a new Builder implementation that uses the provided StageRunner
 // to run all build stages in series.
-func New(stageRun StageRunner) Builder {
-	return builder{
-		stageRun: stageRun,
+func New(ctx context.Context, stageRunFactory StageRunnerFactory, def wharfyml.Definition) (Builder, error) {
+	stageRunners := make([]StageRunner, len(def.Stages))
+	for i, stage := range def.Stages {
+		r, err := stageRunFactory.NewStageRunner(ctx, stage)
+		if err != nil {
+			return nil, fmt.Errorf("stage %s: %w", stage.Name, err)
+		}
+		stageRunners[i] = r
 	}
+	return builder{
+		stageRunners: stageRunners,
+	}, nil
 }
 
-func (b builder) Build(ctx context.Context, def wharfyml.Definition, opt BuildOptions) (Result, error) {
-	result := Result{Options: opt}
+func (b builder) Definition() wharfyml.Definition {
+	return b.def
+}
+
+func (b builder) Build(ctx context.Context) (Result, error) {
+	var result Result
 	start := time.Now()
-	stages := b.filterStages(def.Stages, opt.StageFilter)
-	stagesCount := len(stages)
+	stagesCount := len(b.stageRunners)
 	stagesDone := 0
 	if stagesCount == 0 {
 		log.Warn().
@@ -33,12 +46,12 @@ func (b builder) Build(ctx context.Context, def wharfyml.Definition, opt BuildOp
 		result.Status = StatusNone
 		return result, nil
 	}
-	for _, stage := range stages {
+	for _, stageRunner := range b.stageRunners {
 		log.Info().
 			WithStringf("stages", "%d/%d", stagesDone, stagesCount).
-			WithString("stage", stage.Name).
+			WithString("stage", stageRunner.Stage().Name).
 			Message("Starting stage.")
-		res := b.stageRun.RunStage(ctx, stage)
+		res := stageRunner.RunStage(ctx)
 		result.Stages = append(result.Stages, res)
 		stagesDone++
 		if res.Status != StatusSuccess {

--- a/pkg/worker/builder.go
+++ b/pkg/worker/builder.go
@@ -18,12 +18,15 @@ type builder struct {
 // New returns a new Builder implementation that uses the provided StageRunner
 // to run all build stages in series.
 func New(ctx context.Context, stageRunFactory StageRunnerFactory, def wharfyml.Definition, opts BuildOptions) (Builder, error) {
-	stageRunners := make([]StageRunner, len(def.Stages))
 	filteredStages := filterStages(def.Stages, opts.StageFilter)
+	stageRunners := make([]StageRunner, len(filteredStages))
 	for i, stage := range filteredStages {
 		r, err := stageRunFactory.NewStageRunner(ctx, stage)
 		if err != nil {
 			return nil, fmt.Errorf("stage %s: %w", stage.Name, err)
+		}
+		if r == nil {
+			return nil, fmt.Errorf("stage %s: unexpected nil stage runner", stage.Name)
 		}
 		stageRunners[i] = r
 	}

--- a/pkg/worker/builder.go
+++ b/pkg/worker/builder.go
@@ -19,7 +19,8 @@ type builder struct {
 // to run all build stages in series.
 func New(ctx context.Context, stageRunFactory StageRunnerFactory, def wharfyml.Definition, opts BuildOptions) (Builder, error) {
 	stageRunners := make([]StageRunner, len(def.Stages))
-	for i, stage := range def.Stages {
+	filteredStages := filterStages(def.Stages, opts.StageFilter)
+	for i, stage := range filteredStages {
 		r, err := stageRunFactory.NewStageRunner(ctx, stage)
 		if err != nil {
 			return nil, fmt.Errorf("stage %s: %w", stage.Name, err)
@@ -91,7 +92,7 @@ func (b builder) Build(ctx context.Context) (Result, error) {
 	return result, nil
 }
 
-func (b builder) filterStages(stages []wharfyml.Stage, nameFilter string) []wharfyml.Stage {
+func filterStages(stages []wharfyml.Stage, nameFilter string) []wharfyml.Stage {
 	var result []wharfyml.Stage
 	for _, stage := range stages {
 		if nameFilter == "" || stage.Name == nameFilter {

--- a/pkg/worker/builder_test.go
+++ b/pkg/worker/builder_test.go
@@ -51,7 +51,7 @@ func TestBuilder_runsAllSuccess(t *testing.T) {
 			{Name: "moo"},
 		},
 	}
-	b, err := New(context.Background(), factory, def)
+	b, err := New(context.Background(), factory, def, BuildOptions{})
 	require.NoError(t, err)
 
 	result, err := b.Build(context.Background())
@@ -75,7 +75,7 @@ func TestBuilder_runsMiddleFails(t *testing.T) {
 			{Name: "moo"},
 		},
 	}
-	b, err := New(context.Background(), factory, def)
+	b, err := New(context.Background(), factory, def, BuildOptions{})
 	require.NoError(t, err)
 
 	result, err := b.Build(context.Background())

--- a/pkg/worker/k8srunner.go
+++ b/pkg/worker/k8srunner.go
@@ -25,25 +25,30 @@ import (
 var podInitWaitArgs = []string{"/bin/sh", "-c", "sleep infinite || true"}
 var podInitContinueArgs = []string{"killall", "-s", "SIGINT", "sleep"}
 
+// NewK8s is a helper function that creates a new builder using the
+// NewK8sStepRunnerFactory.
 func NewK8s(ctx context.Context, def wharfyml.Definition, namespace string, restConfig *rest.Config, opts BuildOptions) (Builder, error) {
-	stageFactory, err := NewK8sStageRunnerFactory(ctx, namespace, restConfig)
+	stageFactory, err := NewK8sStageRunnerFactory(namespace, restConfig)
 	if err != nil {
 		return nil, err
 	}
 	return New(ctx, stageFactory, def, opts)
 }
 
-func NewK8sStageRunnerFactory(ctx context.Context, namespace string, restConfig *rest.Config) (StageRunnerFactory, error) {
-	stepFactory, err := NewK8sStepRunnerFactory(ctx, namespace, restConfig)
+// NewK8sStageRunnerFactory is a helper function that creates a new stage runner
+// factory using the NewK8sStepRunnerFactory.
+func NewK8sStageRunnerFactory(namespace string, restConfig *rest.Config) (StageRunnerFactory, error) {
+	stepFactory, err := NewK8sStepRunnerFactory(namespace, restConfig)
 	if err != nil {
 		return nil, err
 	}
-	return NewStageRunnerFactory(ctx, stepFactory)
+	return NewStageRunnerFactory(stepFactory)
 }
 
-// NewK8sStepRunnerFactory returns a new step runner implementation that targets
-// Kubernetes using a specific Kubernetes namespace and REST config.
-func NewK8sStepRunnerFactory(_ context.Context, namespace string, restConfig *rest.Config) (StepRunnerFactory, error) {
+// NewK8sStepRunnerFactory returns a new step runner factory that creates
+// step runners with implementation that targets Kubernetes using a specific
+// Kubernetes namespace and REST config.
+func NewK8sStepRunnerFactory(namespace string, restConfig *rest.Config) (StepRunnerFactory, error) {
 	clientset, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return nil, err

--- a/pkg/worker/k8srunner.go
+++ b/pkg/worker/k8srunner.go
@@ -25,73 +25,137 @@ import (
 var podInitWaitArgs = []string{"/bin/sh", "-c", "sleep infinite || true"}
 var podInitContinueArgs = []string{"killall", "-s", "SIGINT", "sleep"}
 
-type k8sStepRunner struct {
-	namespace  string
-	restConfig *rest.Config
-	clientset  *kubernetes.Clientset
-	pods       corev1.PodInterface
-	events     corev1.EventInterface
+func NewK8s(ctx context.Context, def wharfyml.Definition, namespace string, restConfig *rest.Config) (Builder, error) {
+	stageFactory, err := NewK8sStageRunnerFactory(ctx, namespace, restConfig)
+	if err != nil {
+		return nil, err
+	}
+	return New(ctx, stageFactory, def)
 }
 
-// NewK8sStepRunner returns a new step runner implementation that targets
+func NewK8sStageRunnerFactory(ctx context.Context, namespace string, restConfig *rest.Config) (StageRunnerFactory, error) {
+	stepFactory, err := NewK8sStepRunnerFactory(ctx, namespace, restConfig)
+	if err != nil {
+		return nil, err
+	}
+	return NewStageRunnerFactory(ctx, stepFactory)
+}
+
+// NewK8sStepRunnerFactory returns a new step runner implementation that targets
 // Kubernetes using a specific Kubernetes namespace and REST config.
-func NewK8sStepRunner(namespace string, restConfig *rest.Config) (StepRunner, error) {
+func NewK8sStepRunnerFactory(_ context.Context, namespace string, restConfig *rest.Config) (StepRunnerFactory, error) {
 	clientset, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return nil, err
 	}
-	return k8sStepRunner{
+	return k8sStepRunnerFactory{
 		namespace:  namespace,
 		restConfig: restConfig,
 		clientset:  clientset,
-		pods:       clientset.CoreV1().Pods(namespace),
-		events:     clientset.CoreV1().Events(namespace),
 	}, nil
 }
 
-func (r k8sStepRunner) RunStep(ctx context.Context, step wharfyml.Step) StepResult {
+type k8sStepRunnerFactory struct {
+	namespace  string
+	restConfig *rest.Config
+	clientset  *kubernetes.Clientset
+}
+
+func (f k8sStepRunnerFactory) NewStepRunner(
+	ctx context.Context, step wharfyml.Step) (StepRunner, error) {
 	ctx = contextWithStepName(ctx, step.Name)
+	pod, err := getPodSpec(ctx, step)
+	if err != nil {
+		return nil, err
+	}
+	r := k8sStepRunner{
+		log:        logger.NewScoped(contextStageStepName(ctx)),
+		step:       step,
+		pod:        &pod,
+		namespace:  f.namespace,
+		restConfig: f.restConfig,
+		clientset:  f.clientset,
+		pods:       f.clientset.CoreV1().Pods(f.namespace),
+	}
+	if err := r.dryRunStepError(ctx); err != nil {
+		return nil, fmt.Errorf("dry-run: %w", err)
+	}
+	return r, nil
+}
+
+type k8sStepRunner struct {
+	log        logger.Logger
+	step       wharfyml.Step
+	pod        *v1.Pod
+	namespace  string
+	restConfig *rest.Config
+	clientset  *kubernetes.Clientset
+	pods       corev1.PodInterface
+}
+
+func (r k8sStepRunner) Step() wharfyml.Step {
+	return r.step
+}
+
+func (r k8sStepRunner) RunStep(ctx context.Context) StepResult {
+	ctx = contextWithStepName(ctx, r.step.Name)
 	start := time.Now()
-	err := r.runStepError(ctx, step)
 	status := StatusSuccess
+	err := r.runStepError(ctx)
 	if errors.Is(err, context.Canceled) {
 		status = StatusCancelled
 	} else if err != nil {
 		status = StatusFailed
 	}
 	return StepResult{
-		Name:     step.Name,
+		Name:     r.step.Name,
 		Status:   status,
-		Type:     step.Type.StepTypeName(),
+		Type:     r.step.Type.StepTypeName(),
 		Error:    err,
 		Duration: time.Since(start),
 	}
 }
 
-func (r k8sStepRunner) runStepError(ctx context.Context, step wharfyml.Step) error {
-	pod, err := getPodSpec(ctx, step)
+func (r k8sStepRunner) dryRunStepError(ctx context.Context) error {
+	log.Debug().
+		WithString("step", r.step.Name).
+		WithString("pod", r.pod.GenerateName).
+		Message("DRY RUN: Creating pod.")
+	newPod, err := r.pods.Create(ctx, r.pod, metav1.CreateOptions{
+		DryRun: []string{"All"},
+	})
 	if err != nil {
-		return err
+		return fmt.Errorf("create pod: %w", err)
 	}
 	log.Debug().
-		WithString("step", step.Name).
-		WithString("pod", pod.GenerateName).
+		WithString("step", r.step.Name).
+		WithString("pod", newPod.Name).
+		Message("DRY RUN: Created pod.")
+	return nil
+}
+
+func (r k8sStepRunner) runStepError(ctx context.Context) error {
+	log.Debug().
+		WithString("step", r.step.Name).
+		WithString("pod", r.pod.GenerateName).
 		Message("Creating pod.")
-	newPod, err := r.pods.Create(ctx, &pod, metav1.CreateOptions{})
+	newPod, err := r.pods.Create(ctx, r.pod, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("create pod: %w", err)
 	}
 	var logFunc = func(ev logger.Event) logger.Event {
 		return ev.
-			WithString("step", step.Name).
+			WithString("step", r.step.Name).
 			WithString("pod", newPod.Name)
 	}
+
 	log.Debug().WithFunc(logFunc).Message("Created pod.")
-	defer r.stopPodNow(context.Background(), step.Name, newPod.Name)
+	defer r.stopPodNow(context.Background(), r.step.Name, newPod.Name)
 	log.Debug().WithFunc(logFunc).Message("Waiting for init container to start.")
 	if err := r.waitForInitContainerRunning(ctx, newPod.ObjectMeta); err != nil {
 		return fmt.Errorf("wait for init container: %w", err)
 	}
+
 	log.Debug().WithFunc(logFunc).Message("Transferring repo to init container.")
 	if err := r.copyDirToPod(ctx, ".", "/mnt/repo", r.namespace, newPod.Name, "init"); err != nil {
 		return fmt.Errorf("transfer repo: %w", err)
@@ -108,6 +172,7 @@ func (r k8sStepRunner) runStepError(ctx context.Context, step wharfyml.Step) err
 		}
 		return fmt.Errorf("wait for app container: %w", err)
 	}
+
 	log.Debug().WithFunc(logFunc).Message("App container running. Streaming logs.")
 	if err := r.readLogs(ctx, newPod.Name, &v1.PodLogOptions{Follow: true}); err != nil {
 		return fmt.Errorf("stream logs: %w", err)
@@ -192,7 +257,6 @@ func (r k8sStepRunner) readLogs(ctx context.Context, podName string, opts *v1.Po
 		return err
 	}
 	defer readCloser.Close()
-	podLog := logger.NewScoped(contextStageStepName(ctx))
 	scanner := bufio.NewScanner(readCloser)
 	for scanner.Scan() {
 		txt := scanner.Text()
@@ -200,7 +264,7 @@ func (r k8sStepRunner) readLogs(ctx context.Context, podName string, opts *v1.Po
 		if idx != -1 {
 			txt = txt[idx+1:]
 		}
-		podLog.Info().Message(txt)
+		r.log.Info().Message(txt)
 	}
 	return scanner.Err()
 }

--- a/pkg/worker/k8srunner.go
+++ b/pkg/worker/k8srunner.go
@@ -25,12 +25,12 @@ import (
 var podInitWaitArgs = []string{"/bin/sh", "-c", "sleep infinite || true"}
 var podInitContinueArgs = []string{"killall", "-s", "SIGINT", "sleep"}
 
-func NewK8s(ctx context.Context, def wharfyml.Definition, namespace string, restConfig *rest.Config) (Builder, error) {
+func NewK8s(ctx context.Context, def wharfyml.Definition, namespace string, restConfig *rest.Config, opts BuildOptions) (Builder, error) {
 	stageFactory, err := NewK8sStageRunnerFactory(ctx, namespace, restConfig)
 	if err != nil {
 		return nil, err
 	}
-	return New(ctx, stageFactory, def)
+	return New(ctx, stageFactory, def, opts)
 }
 
 func NewK8sStageRunnerFactory(ctx context.Context, namespace string, restConfig *rest.Config) (StageRunnerFactory, error) {

--- a/pkg/worker/stagerunner.go
+++ b/pkg/worker/stagerunner.go
@@ -13,7 +13,7 @@ import (
 
 // NewStageRunnerFactory returns a new StageRunner that uses the provided
 // StepRunner to run the steps in parallel.
-func NewStageRunnerFactory(ctx context.Context, stepRunFactory StepRunnerFactory) (StageRunnerFactory, error) {
+func NewStageRunnerFactory(stepRunFactory StepRunnerFactory) (StageRunnerFactory, error) {
 	return stageRunnerFactory{stepRunFactory}, nil
 }
 

--- a/pkg/worker/stagerunner.go
+++ b/pkg/worker/stagerunner.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -10,33 +11,59 @@ import (
 	"github.com/iver-wharf/wharf-core/pkg/logger"
 )
 
+// NewStageRunnerFactory returns a new StageRunner that uses the provided
+// StepRunner to run the steps in parallel.
+func NewStageRunnerFactory(ctx context.Context, stepRunFactory StepRunnerFactory) (StageRunnerFactory, error) {
+	return stageRunnerFactory{stepRunFactory}, nil
+}
+
+type stageRunnerFactory struct {
+	stepRunFactory StepRunnerFactory
+}
+
 // NewStageRunner returns a new StageRunner that uses the provided StepRunner to
 // run the steps in parallel.
-func NewStageRunner(stepRun StepRunner) StageRunner {
-	return stageRunner{stepRun}
+func (f stageRunnerFactory) NewStageRunner(ctx context.Context, stage wharfyml.Stage) (StageRunner, error) {
+	return newStageRunner(ctx, f.stepRunFactory, stage)
+}
+
+func newStageRunner(ctx context.Context, stepRunFactory StepRunnerFactory, stage wharfyml.Stage) (StageRunner, error) {
+	ctx = contextWithStageName(ctx, stage.Name)
+	stepRunners := make([]StepRunner, len(stage.Steps))
+	for i, step := range stage.Steps {
+		r, err := stepRunFactory.NewStepRunner(ctx, step)
+		if err != nil {
+			return nil, fmt.Errorf("step %s: %w", step.Name, err)
+		}
+		stepRunners[i] = r
+	}
+	return stageRunner{stage, stepRunners}, nil
 }
 
 type stageRunner struct {
-	stepRun StepRunner
+	stage       wharfyml.Stage
+	stepRunners []StepRunner
 }
 
-func (r stageRunner) RunStage(ctx context.Context, stage wharfyml.Stage) StageResult {
-	ctx = contextWithStageName(ctx, stage.Name)
+func (r stageRunner) Stage() wharfyml.Stage {
+	return r.stage
+}
+
+func (r stageRunner) RunStage(ctx context.Context) StageResult {
+	ctx = contextWithStageName(ctx, r.stage.Name)
 	stageRun := stageRun{
-		stepRun:   r.stepRun,
-		stepCount: len(stage.Steps),
-		stage:     &stage,
+		stepCount: len(r.stepRunners),
+		stage:     &r.stage,
 		start:     time.Now(),
 	}
-	for _, step := range stage.Steps {
-		stageRun.startRunStepGoroutine(ctx, step)
+	for _, stepRunner := range r.stepRunners {
+		stageRun.startRunStepGoroutine(ctx, stepRunner)
 	}
 	return stageRun.waitForResult()
 }
 
 type stageRun struct {
 	stage       *wharfyml.Stage
-	stepRun     StepRunner
 	cancelFuncs []func()
 	stepCount   int
 	stepsDone   int32
@@ -49,11 +76,11 @@ type stageRun struct {
 	mutex sync.Mutex
 }
 
-func (r *stageRun) startRunStepGoroutine(ctx context.Context, step wharfyml.Step) {
+func (r *stageRun) startRunStepGoroutine(ctx context.Context, stepRunner StepRunner) {
 	r.wg.Add(1)
 	stepCtx, cancel := context.WithCancel(ctx)
 	r.cancelFuncs = append(r.cancelFuncs, cancel)
-	go r.runStep(stepCtx, step)
+	go r.runStep(stepCtx, stepRunner)
 }
 
 func (r *stageRun) waitForResult() StageResult {
@@ -77,16 +104,16 @@ func (r *stageRun) addStepResult(res StepResult) {
 	atomic.AddInt32(&r.stepsDone, 1)
 }
 
-func (r *stageRun) runStep(ctx context.Context, step wharfyml.Step) {
+func (r *stageRun) runStep(ctx context.Context, stepRunner StepRunner) {
 	defer r.wg.Done()
 	logFunc := func(ev logger.Event) logger.Event {
 		return ev.
 			WithStringf("steps", "%d/%d", r.stepsDone, r.stepCount).
 			WithString("stage", r.stage.Name).
-			WithString("step", step.Name)
+			WithString("step", stepRunner.Step().Name)
 	}
 	log.Info().WithFunc(logFunc).Message("Starting step.")
-	res := r.stepRun.RunStep(ctx, step)
+	res := stepRunner.RunStep(ctx)
 	r.addStepResult(res)
 	dur := res.Duration.Truncate(time.Second)
 	if res.Status == StatusCancelled {

--- a/pkg/worker/stagerunner_test.go
+++ b/pkg/worker/stagerunner_test.go
@@ -2,22 +2,43 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-type mockStepRunner struct {
-	results map[string]StepResult
-	waits   map[string]bool
+type mockStepRunFactory struct {
+	runners map[string]mockStepRunner
 }
 
-func (r *mockStepRunner) RunStep(ctx context.Context, def wharfyml.Step) StepResult {
-	result := r.results[def.Name]
-	result.Name = def.Name
-	if r.waits[def.Name] {
+func (f mockStepRunFactory) NewStepRunner(
+	ctx context.Context, step wharfyml.Step) (StepRunner, error) {
+	runner, ok := f.runners[step.Name]
+	if !ok {
+		return nil, fmt.Errorf("no step runner found for %q", step.Name)
+	}
+	runner.step.Name = step.Name
+	runner.result.Name = step.Name
+	return runner, nil
+}
+
+type mockStepRunner struct {
+	step   wharfyml.Step
+	result StepResult
+	wait   bool
+}
+
+func (r mockStepRunner) Step() wharfyml.Step {
+	return r.step
+}
+
+func (r mockStepRunner) RunStep(ctx context.Context) StepResult {
+	result := r.result
+	if r.wait {
 		select {
 		case <-ctx.Done():
 			result.Status = StatusCancelled
@@ -29,13 +50,12 @@ func (r *mockStepRunner) RunStep(ctx context.Context, def wharfyml.Step) StepRes
 }
 
 func TestStageRunner_runAllSuccess(t *testing.T) {
-	stepRun := &mockStepRunner{results: map[string]StepResult{
-		"foo": {Status: StatusSuccess},
-		"bar": {Status: StatusSuccess},
-		"moo": {Status: StatusSuccess},
+	factory := mockStepRunFactory{runners: map[string]mockStepRunner{
+		"foo": {result: StepResult{Status: StatusSuccess}},
+		"bar": {result: StepResult{Status: StatusSuccess}},
+		"moo": {result: StepResult{Status: StatusSuccess}},
 	}}
-	b := NewStageRunner(stepRun)
-	def := wharfyml.Stage{
+	stage := wharfyml.Stage{
 		Name: "doesnt-matter",
 		Steps: []wharfyml.Step{
 			{Name: "foo"},
@@ -43,28 +63,23 @@ func TestStageRunner_runAllSuccess(t *testing.T) {
 			{Name: "moo"},
 		},
 	}
-	result := b.RunStage(context.Background(), def)
+	b, err := newStageRunner(context.Background(), factory, stage)
+	require.NoError(t, err)
+	result := b.RunStage(context.Background())
 	assert.Equal(t, StatusSuccess, result.Status)
+
 	gotNames := getNamesFromStepResults(result.Steps)
 	wantNames := []string{"foo", "bar", "moo"}
 	assert.ElementsMatch(t, wantNames, gotNames)
 }
 
 func TestStageRunner_runOneFailsOthersCancelled(t *testing.T) {
-	stepRun := &mockStepRunner{
-		results: map[string]StepResult{
-			"foo": {Status: StatusFailed},
-			"bar": {Status: StatusFailed},
-			"moo": {Status: StatusFailed},
-		},
-		waits: map[string]bool{
-			"foo": true,
-			"bar": true,
-			"moo": false,
-		},
-	}
-	b := NewStageRunner(stepRun)
-	def := wharfyml.Stage{
+	factory := mockStepRunFactory{runners: map[string]mockStepRunner{
+		"foo": {result: StepResult{Status: StatusFailed}, wait: true},
+		"bar": {result: StepResult{Status: StatusFailed}, wait: true},
+		"moo": {result: StepResult{Status: StatusFailed}, wait: false},
+	}}
+	stage := wharfyml.Stage{
 		Name: "doesnt-matter",
 		Steps: []wharfyml.Step{
 			{Name: "foo"},
@@ -72,7 +87,9 @@ func TestStageRunner_runOneFailsOthersCancelled(t *testing.T) {
 			{Name: "moo"},
 		},
 	}
-	result := b.RunStage(context.Background(), def)
+	b, err := newStageRunner(context.Background(), factory, stage)
+	require.NoError(t, err)
+	result := b.RunStage(context.Background())
 	assert.Equal(t, StatusFailed, result.Status)
 
 	gotNames := getNamesFromStepResults(result.Steps)

--- a/pkg/worker/stagerunner_test.go
+++ b/pkg/worker/stagerunner_test.go
@@ -16,7 +16,7 @@ type mockStepRunFactory struct {
 }
 
 func (f mockStepRunFactory) NewStepRunner(
-	ctx context.Context, step wharfyml.Step) (StepRunner, error) {
+	_ context.Context, step wharfyml.Step) (StepRunner, error) {
 	runner, ok := f.runners[step.Name]
 	if !ok {
 		return nil, fmt.Errorf("no step runner found for %q", step.Name)

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -16,25 +16,38 @@ type BuildOptions struct {
 	StageFilter string
 }
 
-// Builder is the interface for running Wharf builds. A single Wharf build may
+// Builder is the interface for running a Wharf build. A single Wharf build may
 // contain any number of stages, which in turn may contain any number of steps.
 // All stages will be run in sequence.
 type Builder interface {
-	Build(ctx context.Context, def wharfyml.Definition, opt BuildOptions) (Result, error)
+	Definition() wharfyml.Definition
+	Build(ctx context.Context) (Result, error)
 }
 
-// StageRunner is the interface for running Wharf build stages. A single Wharf
+// StageRunner is the interface for running a Wharf build stage. A single Wharf
 // build stage may contain any number of steps which will all be run in
 // parallel.
 type StageRunner interface {
-	RunStage(ctx context.Context, def wharfyml.Stage) StageResult
+	Stage() wharfyml.Stage
+	RunStage(ctx context.Context) StageResult
 }
 
-// StepRunner is the interface for running Wharf build steps. Steps are the
+// StageRunnerFactory creates a new StageRunner for a given stage.
+type StageRunnerFactory interface {
+	NewStageRunner(ctx context.Context, stage wharfyml.Stage) (StageRunner, error)
+}
+
+// StepRunner is the interface for running a Wharf build step. Steps are the
 // smallest unit of work in Wharf, and each step represents a single Kubernetes
 // pod or Docker container.
 type StepRunner interface {
-	RunStep(ctx context.Context, def wharfyml.Step) StepResult
+	Step() wharfyml.Step
+	RunStep(ctx context.Context) StepResult
+}
+
+// StepRunnerFactory creates a new StepRunner for a given step.
+type StepRunnerFactory interface {
+	NewStepRunner(ctx context.Context, step wharfyml.Step) (StepRunner, error)
 }
 
 // Result is a Wharf build result with the overall status of all stages were


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed to factory pattern-esque implementation, where it in practice creates all pod specs, scoped loggers, and other preparations before creating the first pod.
- Added pod creation dry-run before first pod is created

## Motivation

Could be expanded later with more preparations such as validating the permissions to perform log watch and remote exec.

Closes #39

Want to move the step type validation from the wharfyml package to the worker package, or a new `steps` package, just to centralize the validation as it's a bit split up right now. However I'm postponing that to a new issue: #65
