### PR TITLE
Added getting Git remotes to pkg/gitstat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   line & column of each parse error. (#48, #58)
 
 - Added build result (logs, status updates) caching via file system. New
-  package in `pkg/resultstore`. (#43)
+  package in `pkg/resultstore`. (#43, #69)
 
 - Added all kubeconfig-related flags from `kubectl` but with a `--k8s-*` prefix.
   This allows e.g Wharf to run as a service account via the `--k8s-as` flag,

--- a/pkg/gitstat/gitstat_test.go
+++ b/pkg/gitstat/gitstat_test.go
@@ -1,0 +1,105 @@
+package gitstat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRemotes(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines []string
+		want  map[string]Remote
+	}{
+		{
+			name:  "empty",
+			lines: nil,
+			want:  map[string]Remote{},
+		},
+		{
+			name: "single push and fetch",
+			lines: []string{
+				"origin\tgit@github.com:iver-wharf/wharf-cmd.git (fetch)",
+				"origin\tgit@github.com:iver-wharf/wharf-cmd.git (push)",
+			},
+			want: map[string]Remote{
+				"origin": {
+					FetchURL: "git@github.com:iver-wharf/wharf-cmd.git",
+					PushURL:  "git@github.com:iver-wharf/wharf-cmd.git",
+				},
+			},
+		},
+		{
+			name: "reverse order",
+			lines: []string{
+				"origin\tgit@github.com:iver-wharf/wharf-cmd.git (push)",
+				"origin\tgit@github.com:iver-wharf/wharf-cmd.git (fetch)",
+			},
+			want: map[string]Remote{
+				"origin": {
+					FetchURL: "git@github.com:iver-wharf/wharf-cmd.git",
+					PushURL:  "git@github.com:iver-wharf/wharf-cmd.git",
+				},
+			},
+		},
+		{
+			name: "only push",
+			lines: []string{
+				"origin\tgit@github.com:iver-wharf/wharf-cmd.git (push)",
+			},
+			want: map[string]Remote{
+				"origin": {PushURL: "git@github.com:iver-wharf/wharf-cmd.git"},
+			},
+		},
+		{
+			name: "only fetch",
+			lines: []string{
+				"origin\tgit@github.com:iver-wharf/wharf-cmd.git (fetch)",
+			},
+			want: map[string]Remote{
+				"origin": {FetchURL: "git@github.com:iver-wharf/wharf-cmd.git"},
+			},
+		},
+		{
+			name: "multiple",
+			lines: []string{
+				"origin\tgit@github.com:iver-wharf/wharf-cmd-fork.git (fetch)",
+				"origin\tgit@github.com:iver-wharf/wharf-cmd-fork.git (push)",
+				"upstream\tgit@github.com:iver-wharf/wharf-cmd.git (fetch)",
+				"upstream\tgit@github.com:iver-wharf/wharf-cmd.git (push)",
+			},
+			want: map[string]Remote{
+				"origin": {
+					FetchURL: "git@github.com:iver-wharf/wharf-cmd-fork.git",
+					PushURL:  "git@github.com:iver-wharf/wharf-cmd-fork.git",
+				},
+				"upstream": {
+					FetchURL: "git@github.com:iver-wharf/wharf-cmd.git",
+					PushURL:  "git@github.com:iver-wharf/wharf-cmd.git",
+				},
+			},
+		},
+		{
+			name: "skips invalid",
+			lines: []string{
+				"origin\tgit@github.com:iver-wharf/wharf-cmd.git (fetch)",
+				"foo bar",
+				"origin\tgit@github.com:iver-wharf/wharf-cmd.git (push)",
+			},
+			want: map[string]Remote{
+				"origin": {
+					FetchURL: "git@github.com:iver-wharf/wharf-cmd.git",
+					PushURL:  "git@github.com:iver-wharf/wharf-cmd.git",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseRemotes(tc.lines)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added fetching remotes via `git remote` command

## Motivation

Need this to later estimate the `REPO_GROUP` and `REPO_NAME` when running locally.
