### PR TITLE
Fixed circular imports for worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   line & column of each parse error. (#48, #58)
 
 - Added build result (logs, status updates) caching via file system. New
-  package in `pkg/resultstore`. (#43, #69)
+  package in `pkg/resultstore`. (#43, #69, #70)
 
 - Added all kubeconfig-related flags from `kubectl` but with a `--k8s-*` prefix.
   This allows e.g Wharf to run as a service account via the `--k8s-as` flag,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml"
 	"github.com/iver-wharf/wharf-cmd/pkg/worker"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -70,7 +71,7 @@ https://iver-wharf.github.io/#/usage-wharfyml/
 			WithDuration("dur", res.Duration.Truncate(time.Second)).
 			WithStringer("status", res.Status).
 			Message("Done with build.")
-		if res.Status != worker.StatusSuccess {
+		if res.Status != workermodel.StatusSuccess {
 			return errors.New("build failed")
 		}
 		return nil

--- a/pkg/provisioner/worker.go
+++ b/pkg/provisioner/worker.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/iver-wharf/wharf-cmd/pkg/worker"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -14,7 +14,7 @@ import (
 type Worker struct {
 	ID        string
 	Name      string
-	Status    worker.Status
+	Status    workermodel.Status
 	CreatedAt time.Time
 }
 
@@ -30,19 +30,19 @@ func convertPodToWorker(pod *v1.Pod) Worker {
 	if pod == nil {
 		return Worker{}
 	}
-	var status worker.Status = worker.StatusUnknown
+	var status workermodel.Status = workermodel.StatusUnknown
 	if pod.Status.Phase == v1.PodUnknown {
-		status = worker.StatusUnknown
+		status = workermodel.StatusUnknown
 	} else if pod.Status.Phase == v1.PodSucceeded {
-		status = worker.StatusSuccess
+		status = workermodel.StatusSuccess
 	} else if pod.Status.Phase == v1.PodFailed {
-		status = worker.StatusFailed
+		status = workermodel.StatusFailed
 	} else if anyContainerIsRunning(pod.Status.InitContainerStatuses) {
-		status = worker.StatusInitializing
+		status = workermodel.StatusInitializing
 	} else if anyContainerIsRunning(pod.Status.ContainerStatuses) {
-		status = worker.StatusRunning
+		status = workermodel.StatusRunning
 	} else if podConditionIsTrue(pod.Status.Conditions, v1.PodScheduled) {
-		status = worker.StatusScheduling
+		status = workermodel.StatusScheduling
 	}
 
 	return Worker{

--- a/pkg/provisioner/worker_test.go
+++ b/pkg/provisioner/worker_test.go
@@ -3,7 +3,7 @@ package provisioner
 import (
 	"testing"
 
-	"github.com/iver-wharf/wharf-cmd/pkg/worker"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,7 +42,7 @@ func TestConvertPodToWorker_Status(t *testing.T) {
 	testCases := []struct {
 		name string
 		pod  v1.Pod
-		want worker.Status
+		want workermodel.Status
 	}{
 		{
 			name: "scheduling",
@@ -51,7 +51,7 @@ func TestConvertPodToWorker_Status(t *testing.T) {
 					Type:   v1.PodScheduled,
 					Status: v1.ConditionTrue,
 				}}}),
-			want: worker.StatusScheduling,
+			want: workermodel.StatusScheduling,
 		},
 		{
 			name: "initializing",
@@ -61,7 +61,7 @@ func TestConvertPodToWorker_Status(t *testing.T) {
 						Running: &v1.ContainerStateRunning{},
 					},
 				}}}),
-			want: worker.StatusInitializing,
+			want: workermodel.StatusInitializing,
 		},
 		{
 			name: "running",
@@ -71,27 +71,27 @@ func TestConvertPodToWorker_Status(t *testing.T) {
 						Running: &v1.ContainerStateRunning{},
 					},
 				}}}),
-			want: worker.StatusRunning,
+			want: workermodel.StatusRunning,
 		},
 		{
 			name: "success",
 			pod:  makeTestPodWithPhase(v1.PodSucceeded),
-			want: worker.StatusSuccess,
+			want: workermodel.StatusSuccess,
 		},
 		{
 			name: "failed",
 			pod:  makeTestPodWithPhase(v1.PodFailed),
-			want: worker.StatusFailed,
+			want: workermodel.StatusFailed,
 		},
 		{
 			name: "unknown_explicit",
 			pod:  makeTestPodWithPhase(v1.PodUnknown),
-			want: worker.StatusUnknown,
+			want: workermodel.StatusUnknown,
 		},
 		{
 			name: "unknown_implicit",
 			pod:  makeTestPod(v1.PodStatus{}),
-			want: worker.StatusUnknown,
+			want: workermodel.StatusUnknown,
 		},
 	}
 
@@ -138,17 +138,17 @@ func TestConvertPodsToWorkers(t *testing.T) {
 		{
 			ID:     "first-uid-420",
 			Name:   "first-namespace/first-name",
-			Status: worker.StatusUnknown,
+			Status: workermodel.StatusUnknown,
 		},
 		{
 			ID:     "second-uid-420",
 			Name:   "first-namespace/second-name",
-			Status: worker.StatusUnknown,
+			Status: workermodel.StatusUnknown,
 		},
 		{
 			ID:     "third-uid-420",
 			Name:   "second-namespace/third-name",
-			Status: worker.StatusUnknown,
+			Status: workermodel.StatusUnknown,
 		},
 	}
 	gotWorkers := convertPodsToWorkers(pods)

--- a/pkg/resultstore/artifact.go
+++ b/pkg/resultstore/artifact.go
@@ -7,14 +7,14 @@ import (
 	"io/fs"
 	"path/filepath"
 
-	"github.com/iver-wharf/wharf-cmd/pkg/worker"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 )
 
 var (
 	fileNameArtifactEvents = "artifacts.json"
 )
 
-func (s *store) AddArtifactEvent(stepID uint64, artifactMeta worker.ArtifactMeta) error {
+func (s *store) AddArtifactEvent(stepID uint64, artifactMeta workermodel.ArtifactMeta) error {
 	s.artifactMutex.Lock(stepID)
 	defer s.artifactMutex.Unlock(stepID)
 	list, err := s.readArtifactEventsFile(stepID)

--- a/pkg/resultstore/artifact_test.go
+++ b/pkg/resultstore/artifact_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/iver-wharf/wharf-cmd/pkg/worker"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -129,7 +129,7 @@ func TestStore_AddArtifactEventFirst(t *testing.T) {
 		},
 	})
 	const stepID uint64 = 1
-	err := s.AddArtifactEvent(stepID, worker.ArtifactMeta{Name: "artifact-1"})
+	err := s.AddArtifactEvent(stepID, workermodel.ArtifactMeta{Name: "artifact-1"})
 	require.NoError(t, err)
 	want := `
 {
@@ -164,7 +164,7 @@ func TestStore_AddArtifactEventSecond(t *testing.T) {
 		},
 	})
 	const stepID uint64 = 1
-	err := s.AddArtifactEvent(stepID, worker.ArtifactMeta{Name: "artifact-2"})
+	err := s.AddArtifactEvent(stepID, workermodel.ArtifactMeta{Name: "artifact-2"})
 	require.NoError(t, err)
 	want := `
 {
@@ -295,7 +295,7 @@ func TestStore_PubSubArtifactEvents(t *testing.T) {
 	const buffer = 1
 	const stepID uint64 = 1
 	ch := subArtifactEventsNoErr(t, s, buffer)
-	err := s.AddArtifactEvent(stepID, worker.ArtifactMeta{Name: "artifact-1"})
+	err := s.AddArtifactEvent(stepID, workermodel.ArtifactMeta{Name: "artifact-1"})
 	require.NoError(t, err)
 
 	select {

--- a/pkg/resultstore/resultstore.go
+++ b/pkg/resultstore/resultstore.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/iver-wharf/wharf-cmd/pkg/worker"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 )
 
 var (
@@ -42,10 +42,10 @@ type StatusList struct {
 
 // StatusUpdate is an update to a status of a build step.
 type StatusUpdate struct {
-	StepID    uint64        `json:"-"`
-	UpdateID  uint64        `json:"updateId"`
-	Timestamp time.Time     `json:"timestamp"`
-	Status    worker.Status `json:"status"`
+	StepID    uint64             `json:"-"`
+	UpdateID  uint64             `json:"updateId"`
+	Timestamp time.Time          `json:"timestamp"`
+	Status    workermodel.Status `json:"status"`
 }
 
 // ArtifactEventList is a list of artifact events. This is the data structure
@@ -88,7 +88,7 @@ type Store interface {
 	// update found for the step is the same as the new status, then this
 	// status update is skipped. Any written status update is also published to
 	// any active subscriptions.
-	AddStatusUpdate(stepID uint64, timestamp time.Time, newStatus worker.Status) error
+	AddStatusUpdate(stepID uint64, timestamp time.Time, newStatus workermodel.Status) error
 
 	// SubAllStatusUpdates creates a new channel that streams all status updates
 	// from this result store since the beginning, and keeps on streaming new
@@ -101,7 +101,7 @@ type Store interface {
 
 	// AddArtifactEvent adds an artifact event to a step.
 	// Any written artifact event is also published to any active subscriptions.
-	AddArtifactEvent(stepID uint64, artifactMeta worker.ArtifactMeta) error
+	AddArtifactEvent(stepID uint64, artifactMeta workermodel.ArtifactMeta) error
 
 	// SubAllArtifactEvents creates a new channel that streams all artifact
 	// events from this result store since the beginning, and keeps on

--- a/pkg/resultstore/status.go
+++ b/pkg/resultstore/status.go
@@ -8,14 +8,14 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/iver-wharf/wharf-cmd/pkg/worker"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 )
 
 var (
 	fileNameStatusUpdates = "status.json"
 )
 
-func (s *store) AddStatusUpdate(stepID uint64, timestamp time.Time, newStatus worker.Status) error {
+func (s *store) AddStatusUpdate(stepID uint64, timestamp time.Time, newStatus workermodel.Status) error {
 	s.statusMutex.Lock(stepID)
 	defer s.statusMutex.Unlock(stepID)
 	list, err := s.readStatusUpdatesFile(stepID)

--- a/pkg/resultstore/status_test.go
+++ b/pkg/resultstore/status_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/iver-wharf/wharf-cmd/pkg/worker"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,19 +46,19 @@ func TestStore_ReadStatusUpdatesFile(t *testing.T) {
 				StepID:    stepID,
 				UpdateID:  1,
 				Timestamp: wantTime,
-				Status:    worker.StatusScheduling,
+				Status:    workermodel.StatusScheduling,
 			},
 			{
 				StepID:    stepID,
 				UpdateID:  2,
 				Timestamp: wantTime,
-				Status:    worker.StatusRunning,
+				Status:    workermodel.StatusRunning,
 			},
 			{
 				StepID:    stepID,
 				UpdateID:  3,
 				Timestamp: wantTime,
-				Status:    worker.StatusFailed,
+				Status:    workermodel.StatusFailed,
 			},
 		},
 	}
@@ -81,19 +81,19 @@ func TestStore_WriteStatusUpdatesFile(t *testing.T) {
 				StepID:    stepID,
 				UpdateID:  1,
 				Timestamp: sampleTime,
-				Status:    worker.StatusScheduling,
+				Status:    workermodel.StatusScheduling,
 			},
 			{
 				StepID:    stepID,
 				UpdateID:  2,
 				Timestamp: sampleTime,
-				Status:    worker.StatusRunning,
+				Status:    workermodel.StatusRunning,
 			},
 			{
 				StepID:    stepID,
 				UpdateID:  3,
 				Timestamp: sampleTime,
-				Status:    worker.StatusFailed,
+				Status:    workermodel.StatusFailed,
 			},
 		},
 	}
@@ -140,7 +140,7 @@ func TestStore_AddStatusUpdateFirst(t *testing.T) {
 		},
 	})
 	const stepID uint64 = 1
-	err := s.AddStatusUpdate(stepID, sampleTime, worker.StatusCancelled)
+	err := s.AddStatusUpdate(stepID, sampleTime, workermodel.StatusCancelled)
 	require.NoError(t, err)
 	want := fmt.Sprintf(`
 {
@@ -176,7 +176,7 @@ func TestStore_AddStatusUpdateSecond(t *testing.T) {
 		},
 	})
 	const stepID uint64 = 1
-	err := s.AddStatusUpdate(stepID, sampleTime, worker.StatusCancelled)
+	err := s.AddStatusUpdate(stepID, sampleTime, workermodel.StatusCancelled)
 	require.NoError(t, err)
 	want := fmt.Sprintf(`
 {
@@ -215,17 +215,17 @@ func TestStore_AddStatusUpdateSkipIfSameStatus(t *testing.T) {
 			return nil, errors.New("should not write")
 		},
 	})
-	err := s.AddStatusUpdate(1, time.Now(), worker.StatusCancelled)
+	err := s.AddStatusUpdate(1, time.Now(), workermodel.StatusCancelled)
 	require.NoError(t, err)
 }
 
 func TestStore_SubStatusUpdatesSendsAllOldStatuses(t *testing.T) {
 	updates1 := []StatusUpdate{
-		{StepID: 1, UpdateID: 1, Status: worker.StatusCancelled},
+		{StepID: 1, UpdateID: 1, Status: workermodel.StatusCancelled},
 	}
 	updates2 := []StatusUpdate{
-		{StepID: 2, UpdateID: 1, Status: worker.StatusRunning},
-		{StepID: 2, UpdateID: 2, Status: worker.StatusSuccess},
+		{StepID: 2, UpdateID: 1, Status: workermodel.StatusRunning},
+		{StepID: 2, UpdateID: 2, Status: workermodel.StatusSuccess},
 	}
 	oldLists := map[string]StatusList{
 		filepath.Join(dirNameSteps, "1", fileNameStatusUpdates): {
@@ -329,7 +329,7 @@ func TestStore_PubSubStatusUpdates(t *testing.T) {
 	const buffer = 1
 	const stepID uint64 = 1
 	ch := subStatusUpdatesNoErr(t, s, buffer)
-	err := s.AddStatusUpdate(stepID, sampleTime, worker.StatusCancelled)
+	err := s.AddStatusUpdate(stepID, sampleTime, workermodel.StatusCancelled)
 	require.NoError(t, err)
 
 	select {
@@ -338,7 +338,7 @@ func TestStore_PubSubStatusUpdates(t *testing.T) {
 		want := StatusUpdate{
 			StepID:    stepID,
 			UpdateID:  1,
-			Status:    worker.StatusCancelled,
+			Status:    workermodel.StatusCancelled,
 			Timestamp: sampleTime,
 		}
 		assert.Equal(t, want, got)

--- a/pkg/watchdog/watchdog.go
+++ b/pkg/watchdog/watchdog.go
@@ -9,7 +9,7 @@ import (
 	"github.com/iver-wharf/wharf-api-client-go/v2/pkg/wharfapi"
 	"github.com/iver-wharf/wharf-cmd/pkg/provisioner"
 	"github.com/iver-wharf/wharf-cmd/pkg/provisionerclient"
-	"github.com/iver-wharf/wharf-cmd/pkg/worker"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 	"github.com/iver-wharf/wharf-core/pkg/logger"
 )
 
@@ -231,10 +231,10 @@ func (wd *watchdog) getRunningWorkers() ([]provisioner.Worker, error) {
 	var runningWorkers []provisioner.Worker
 	for _, w := range allWorkers {
 		switch w.Status {
-		case worker.StatusInitializing,
-			worker.StatusScheduling,
-			worker.StatusRunning,
-			worker.StatusNone:
+		case workermodel.StatusInitializing,
+			workermodel.StatusScheduling,
+			workermodel.StatusRunning,
+			workermodel.StatusNone:
 			allWorkers = append(allWorkers, w)
 		}
 	}

--- a/pkg/worker/builder.go
+++ b/pkg/worker/builder.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 )
 
 type builder struct {
@@ -52,7 +53,7 @@ func (b builder) Build(ctx context.Context) (Result, error) {
 		log.Warn().
 			WithString("stages", "0/0").
 			Message("No stages to run.")
-		result.Status = StatusNone
+		result.Status = workermodel.StatusNone
 		return result, nil
 	}
 	for _, stageRunner := range b.stageRunners {
@@ -63,13 +64,13 @@ func (b builder) Build(ctx context.Context) (Result, error) {
 		res := stageRunner.RunStage(ctx)
 		result.Stages = append(result.Stages, res)
 		stagesDone++
-		if res.Status != StatusSuccess {
+		if res.Status != workermodel.StatusSuccess {
 			var failed []string
 			var cancelled []string
 			for _, stepRes := range res.Steps {
-				if stepRes.Status == StatusFailed {
+				if stepRes.Status == workermodel.StatusFailed {
 					failed = append(failed, stepRes.Name)
-				} else if stepRes.Status == StatusCancelled {
+				} else if stepRes.Status == workermodel.StatusCancelled {
 					cancelled = append(cancelled, stepRes.Name)
 				}
 			}
@@ -89,7 +90,7 @@ func (b builder) Build(ctx context.Context) (Result, error) {
 			WithString("stage", res.Name).
 			WithDuration("dur", res.Duration.Truncate(time.Second)).
 			Message("Done with stage.")
-		result.Status = StatusSuccess
+		result.Status = workermodel.StatusSuccess
 	}
 	result.Duration = time.Since(start)
 	return result, nil

--- a/pkg/worker/builder_test.go
+++ b/pkg/worker/builder_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -40,9 +41,9 @@ func (r mockStageRunner) RunStage(context.Context) StageResult {
 
 func TestBuilder_runsAllSuccess(t *testing.T) {
 	factory := &mockStageRunFactory{runners: map[string]mockStageRunner{
-		"foo": {result: StageResult{Status: StatusSuccess}},
-		"bar": {result: StageResult{Status: StatusSuccess}},
-		"moo": {result: StageResult{Status: StatusSuccess}},
+		"foo": {result: StageResult{Status: workermodel.StatusSuccess}},
+		"bar": {result: StageResult{Status: workermodel.StatusSuccess}},
+		"moo": {result: StageResult{Status: workermodel.StatusSuccess}},
 	}}
 	def := wharfyml.Definition{
 		Stages: []wharfyml.Stage{
@@ -56,7 +57,7 @@ func TestBuilder_runsAllSuccess(t *testing.T) {
 
 	result, err := b.Build(context.Background())
 	require.NoError(t, err, "builder.Build")
-	assert.Equal(t, StatusSuccess, result.Status, "result.Status")
+	assert.Equal(t, workermodel.StatusSuccess, result.Status, "result.Status")
 	gotNames := getNamesFromStageResults(result.Stages)
 	wantNames := []string{"foo", "bar", "moo"}
 	assert.ElementsMatch(t, gotNames, wantNames, "result.Stages[].Name")
@@ -64,9 +65,9 @@ func TestBuilder_runsAllSuccess(t *testing.T) {
 
 func TestBuilder_runsMiddleFails(t *testing.T) {
 	factory := &mockStageRunFactory{runners: map[string]mockStageRunner{
-		"foo": {result: StageResult{Status: StatusSuccess}},
-		"bar": {result: StageResult{Status: StatusFailed}},
-		"moo": {result: StageResult{Status: StatusSuccess}},
+		"foo": {result: StageResult{Status: workermodel.StatusSuccess}},
+		"bar": {result: StageResult{Status: workermodel.StatusFailed}},
+		"moo": {result: StageResult{Status: workermodel.StatusSuccess}},
 	}}
 	def := wharfyml.Definition{
 		Stages: []wharfyml.Stage{
@@ -80,10 +81,10 @@ func TestBuilder_runsMiddleFails(t *testing.T) {
 
 	result, err := b.Build(context.Background())
 	require.NoError(t, err, "builder.Build")
-	assert.Equal(t, StatusFailed, result.Status, "result.Status")
+	assert.Equal(t, workermodel.StatusFailed, result.Status, "result.Status")
 	require.Len(t, result.Stages, 2, "result.Stages")
-	assert.Equal(t, StatusSuccess, result.Stages[0].Status)
-	assert.Equal(t, StatusFailed, result.Stages[1].Status)
+	assert.Equal(t, workermodel.StatusSuccess, result.Stages[0].Status)
+	assert.Equal(t, workermodel.StatusFailed, result.Stages[1].Status)
 }
 
 func getNamesFromStageResults(stages []StageResult) []string {

--- a/pkg/worker/k8srunner.go
+++ b/pkg/worker/k8srunner.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/iver-wharf/wharf-cmd/pkg/tarutil"
 	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 	"github.com/iver-wharf/wharf-core/pkg/logger"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,12 +106,12 @@ func (r k8sStepRunner) Step() wharfyml.Step {
 func (r k8sStepRunner) RunStep(ctx context.Context) StepResult {
 	ctx = contextWithStepName(ctx, r.step.Name)
 	start := time.Now()
-	status := StatusSuccess
+	status := workermodel.StatusSuccess
 	err := r.runStepError(ctx)
 	if errors.Is(err, context.Canceled) {
-		status = StatusCancelled
+		status = workermodel.StatusCancelled
 	} else if err != nil {
-		status = StatusFailed
+		status = workermodel.StatusFailed
 	}
 	return StepResult{
 		Name:     r.step.Name,

--- a/pkg/worker/stagerunner.go
+++ b/pkg/worker/stagerunner.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 	"github.com/iver-wharf/wharf-core/pkg/logger"
 )
 
@@ -85,9 +86,9 @@ func (r *stageRun) startRunStepGoroutine(ctx context.Context, stepRunner StepRun
 
 func (r *stageRun) waitForResult() StageResult {
 	r.wg.Wait()
-	status := StatusSuccess
+	status := workermodel.StatusSuccess
 	if r.failed {
-		status = StatusFailed
+		status = workermodel.StatusFailed
 	}
 	return StageResult{
 		Name:     r.stage.Name,
@@ -116,12 +117,12 @@ func (r *stageRun) runStep(ctx context.Context, stepRunner StepRunner) {
 	res := stepRunner.RunStep(ctx)
 	r.addStepResult(res)
 	dur := res.Duration.Truncate(time.Second)
-	if res.Status == StatusCancelled {
+	if res.Status == workermodel.StatusCancelled {
 		log.Info().
 			WithFunc(logFunc).
 			WithDuration("dur", dur).
 			Message("Cancelled pod.")
-	} else if res.Status != StatusSuccess {
+	} else if res.Status != workermodel.StatusSuccess {
 		r.failed = true
 		log.Warn().
 			WithError(res.Error).

--- a/pkg/worker/stagerunner_test.go
+++ b/pkg/worker/stagerunner_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,9 +42,9 @@ func (r mockStepRunner) RunStep(ctx context.Context) StepResult {
 	if r.wait {
 		select {
 		case <-ctx.Done():
-			result.Status = StatusCancelled
+			result.Status = workermodel.StatusCancelled
 		case <-time.After(time.Second):
-			result.Status = StatusUnknown
+			result.Status = workermodel.StatusUnknown
 		}
 	}
 	return result
@@ -51,9 +52,9 @@ func (r mockStepRunner) RunStep(ctx context.Context) StepResult {
 
 func TestStageRunner_runAllSuccess(t *testing.T) {
 	factory := mockStepRunFactory{runners: map[string]mockStepRunner{
-		"foo": {result: StepResult{Status: StatusSuccess}},
-		"bar": {result: StepResult{Status: StatusSuccess}},
-		"moo": {result: StepResult{Status: StatusSuccess}},
+		"foo": {result: StepResult{Status: workermodel.StatusSuccess}},
+		"bar": {result: StepResult{Status: workermodel.StatusSuccess}},
+		"moo": {result: StepResult{Status: workermodel.StatusSuccess}},
 	}}
 	stage := wharfyml.Stage{
 		Name: "doesnt-matter",
@@ -66,7 +67,7 @@ func TestStageRunner_runAllSuccess(t *testing.T) {
 	b, err := newStageRunner(context.Background(), factory, stage)
 	require.NoError(t, err)
 	result := b.RunStage(context.Background())
-	assert.Equal(t, StatusSuccess, result.Status)
+	assert.Equal(t, workermodel.StatusSuccess, result.Status)
 
 	gotNames := getNamesFromStepResults(result.Steps)
 	wantNames := []string{"foo", "bar", "moo"}
@@ -75,9 +76,9 @@ func TestStageRunner_runAllSuccess(t *testing.T) {
 
 func TestStageRunner_runOneFailsOthersCancelled(t *testing.T) {
 	factory := mockStepRunFactory{runners: map[string]mockStepRunner{
-		"foo": {result: StepResult{Status: StatusFailed}, wait: true},
-		"bar": {result: StepResult{Status: StatusFailed}, wait: true},
-		"moo": {result: StepResult{Status: StatusFailed}, wait: false},
+		"foo": {result: StepResult{Status: workermodel.StatusFailed}, wait: true},
+		"bar": {result: StepResult{Status: workermodel.StatusFailed}, wait: true},
+		"moo": {result: StepResult{Status: workermodel.StatusFailed}, wait: false},
 	}}
 	stage := wharfyml.Stage{
 		Name: "doesnt-matter",
@@ -90,17 +91,17 @@ func TestStageRunner_runOneFailsOthersCancelled(t *testing.T) {
 	b, err := newStageRunner(context.Background(), factory, stage)
 	require.NoError(t, err)
 	result := b.RunStage(context.Background())
-	assert.Equal(t, StatusFailed, result.Status)
+	assert.Equal(t, workermodel.StatusFailed, result.Status)
 
 	gotNames := getNamesFromStepResults(result.Steps)
 	wantNames := []string{"foo", "bar", "moo"}
 	assert.ElementsMatch(t, wantNames, gotNames)
 
 	gotStatuses := getStatusesFromStepResults(result.Steps)
-	wantStatuses := map[string]Status{
-		"foo": StatusCancelled,
-		"bar": StatusCancelled,
-		"moo": StatusFailed,
+	wantStatuses := map[string]workermodel.Status{
+		"foo": workermodel.StatusCancelled,
+		"bar": workermodel.StatusCancelled,
+		"moo": workermodel.StatusFailed,
 	}
 	assert.Equal(t, wantStatuses, gotStatuses)
 }
@@ -113,8 +114,8 @@ func getNamesFromStepResults(steps []StepResult) []string {
 	return names
 }
 
-func getStatusesFromStepResults(steps []StepResult) map[string]Status {
-	statuses := make(map[string]Status)
+func getStatusesFromStepResults(steps []StepResult) map[string]workermodel.Status {
+	statuses := make(map[string]workermodel.Status)
 	for _, step := range steps {
 		statuses[step.Name] = step.Status
 	}

--- a/pkg/worker/status_test.go
+++ b/pkg/worker/status_test.go
@@ -4,15 +4,16 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStatusMarshalJSON(t *testing.T) {
 	got, err := json.Marshal(struct {
-		MyStatus Status
+		MyStatus workermodel.Status
 	}{
-		MyStatus: StatusSuccess,
+		MyStatus: workermodel.StatusSuccess,
 	})
 	require.NoError(t, err)
 	want := `{"MyStatus": "Success"}`
@@ -21,20 +22,20 @@ func TestStatusMarshalJSON(t *testing.T) {
 
 func TestStatusUnmarshalJSON(t *testing.T) {
 	var myStruct struct {
-		MyStatus Status
+		MyStatus workermodel.Status
 	}
 	b := []byte(`{"MyStatus": "Success"}`)
 	err := json.Unmarshal(b, &myStruct)
 	require.NoError(t, err)
-	assert.Equal(t, StatusSuccess, myStruct.MyStatus)
+	assert.Equal(t, workermodel.StatusSuccess, myStruct.MyStatus)
 }
 
 func TestStatusPtrUnmarshalJSON(t *testing.T) {
 	var myStruct struct {
-		MyStatus *Status
+		MyStatus *workermodel.Status
 	}
 	b := []byte(`{"MyStatus": "Success"}`)
 	err := json.Unmarshal(b, &myStruct)
 	require.NoError(t, err)
-	assert.Equal(t, StatusSuccess, *myStruct.MyStatus)
+	assert.Equal(t, workermodel.StatusSuccess, *myStruct.MyStatus)
 }

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 	"github.com/iver-wharf/wharf-core/pkg/logger"
 )
 
@@ -54,28 +55,28 @@ type StepRunnerFactory interface {
 // executed, the induvidual stage results, as well as the duration of the entire
 // Wharf build.
 type Result struct {
-	Status   Status        // execution status of the entire build
-	Options  BuildOptions  // options used when running the build
-	Stages   []StageResult // execution results for each stage
-	Duration time.Duration // execution duration of the entire build
+	Status   workermodel.Status // execution status of the entire build
+	Options  BuildOptions       // options used when running the build
+	Stages   []StageResult      // execution results for each stage
+	Duration time.Duration      // execution duration of the entire build
 }
 
 // StageResult is a Wharf build stage result with the overall status of the
 // steps that was executed for the stage, as well as the duration of the
 // Wharf build stage.
 type StageResult struct {
-	Name     string        // name of the stage
-	Status   Status        // execution status of the stage
-	Steps    []StepResult  // execution results for each step
-	Duration time.Duration // execution duration of the stage
+	Name     string             // name of the stage
+	Status   workermodel.Status // execution status of the stage
+	Steps    []StepResult       // execution results for each step
+	Duration time.Duration      // execution duration of the stage
 }
 
 // StepResult is a Wharf build step result with the status of the step execution
 // as well as the duration of the Wharf build step.
 type StepResult struct {
-	Name     string        // name of the step
-	Status   Status        // execution status of the step
-	Type     string        // type of Wharf build step, eg. "container" or "docker"
-	Error    error         // error message from the execution, if any
-	Duration time.Duration // execution duration of the step
+	Name     string             // name of the step
+	Status   workermodel.Status // execution status of the step
+	Type     string             // type of Wharf build step, eg. "container" or "docker"
+	Error    error              // error message from the execution, if any
+	Duration time.Duration      // execution duration of the step
 }

--- a/pkg/worker/workermodel/artifact.go
+++ b/pkg/worker/workermodel/artifact.go
@@ -1,4 +1,4 @@
-package worker
+package workermodel
 
 // ArtifactMeta holds metadata about an artifact created during building.
 type ArtifactMeta struct {

--- a/pkg/worker/workermodel/status.go
+++ b/pkg/worker/workermodel/status.go
@@ -1,4 +1,4 @@
-package worker
+package workermodel
 
 import (
 	"encoding/json"

--- a/pkg/workerapi/workerserver/grpcserver.go
+++ b/pkg/workerapi/workerserver/grpcserver.go
@@ -5,7 +5,7 @@ import (
 
 	v1 "github.com/iver-wharf/wharf-cmd/api/workerapi/v1"
 	"github.com/iver-wharf/wharf-cmd/pkg/resultstore"
-	"github.com/iver-wharf/wharf-cmd/pkg/worker"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -130,21 +130,21 @@ func ConvertToStreamStatusEventsResponse(update resultstore.StatusUpdate) *v1.St
 	}
 }
 
-func convertToStreamStatusEventsResponseStatus(status worker.Status) v1.StreamStatusEventsResponseStatus {
+func convertToStreamStatusEventsResponseStatus(status workermodel.Status) v1.StreamStatusEventsResponseStatus {
 	switch status {
-	case worker.StatusNone:
+	case workermodel.StatusNone:
 		return v1.StreamStatusEventsResponsePending
-	case worker.StatusScheduling:
+	case workermodel.StatusScheduling:
 		return v1.StreamStatusEventsResponseScheduling
-	case worker.StatusInitializing:
+	case workermodel.StatusInitializing:
 		return v1.StreamStatusEventsResponseInitializing
-	case worker.StatusRunning:
+	case workermodel.StatusRunning:
 		return v1.StreamStatusEventsResponseRunning
-	case worker.StatusSuccess:
+	case workermodel.StatusSuccess:
 		return v1.StreamStatusEventsResponseSuccess
-	case worker.StatusFailed:
+	case workermodel.StatusFailed:
 		return v1.StreamStatusEventsResponseFailed
-	case worker.StatusCancelled:
+	case workermodel.StatusCancelled:
 		return v1.StreamStatusEventsResponseCancelled
 	default:
 		return v1.StreamStatusEventsResponseUnspecified


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Changed references to `worker.Status` and `worker.ArtifactMeta` with `workermodel.Status` and `workermodel.ArtifactMeta` respectively.

## Motivation

Tried to use `pkg/resultstore` and `pkg/workerserver` in `pkg/worker` but was unable to due to circular imports.
This fixes that.