### PR TITLE
Built-in variables

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -50,7 +49,7 @@ https://iver-wharf.github.io/#/usage-wharfyml/
 		currentDir := filepath.Dir(ymlAbsPath)
 		source, errs := wharfyml.ParseVarFiles(currentDir)
 		if len(errs) > 0 {
-			logParseErrors(errs)
+			logParseErrors(errs, currentDir)
 			return errors.New("failed to parse variable files")
 		}
 		def, errs := wharfyml.ParseFile(ymlAbsPath, wharfyml.Args{
@@ -58,7 +57,7 @@ https://iver-wharf.github.io/#/usage-wharfyml/
 			VarSource: source,
 		})
 		if len(errs) > 0 {
-			logParseErrors(errs)
+			logParseErrors(errs, currentDir)
 			return errors.New("failed to parse .wharf-ci.yml")
 		}
 		log.Debug().Message("Successfully parsed .wharf-ci.yml")
@@ -91,7 +90,7 @@ https://iver-wharf.github.io/#/usage-wharfyml/
 	},
 }
 
-func logParseErrors(errs wharfyml.Errors) {
+func logParseErrors(errs wharfyml.Errors, currentDir string) {
 	log.Warn().WithInt("errors", len(errs)).Message("Cannot run build due to parsing errors.")
 	for _, err := range errs {
 		var posErr wharfyml.PosError
@@ -111,10 +110,6 @@ func logParseErrors(errs wharfyml.Errors) {
 		}
 	}
 	if containsMissingBuiltin {
-		currentDir, err := os.Getwd()
-		if err != nil {
-			currentDir = "."
-		}
 		varFiles := wharfyml.ListPossibleVarsFiles(currentDir)
 		var sb strings.Builder
 		sb.WriteString("You can add built-in variables in the following files:")
@@ -134,7 +129,8 @@ Wharf also looks for
 Sample content:
 	# .wharf-vars.yml
 	vars:
-	  REG_URL: http://harbor.example.com`)
+	  REG_URL: http://harbor.example.com
+`)
 		log.Info().Message(sb.String())
 	}
 }

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -1,0 +1,9 @@
+package slices
+
+// ReverseStrings will reverse the order of all elements in the slice in place,
+// meaning it will alter the existing slice.
+func ReverseStrings(slice []string) {
+	for i, j := 0, len(slice)-1; i < len(slice)/2; i, j = i+1, j-1 {
+		slice[i], slice[j] = slice[j], slice[i]
+	}
+}

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -3,7 +3,15 @@ package slices
 // ReverseStrings will reverse the order of all elements in the slice in place,
 // meaning it will alter the existing slice.
 func ReverseStrings(slice []string) {
-	for i, j := 0, len(slice)-1; i < len(slice)/2; i, j = i+1, j-1 {
+	Reverse(len(slice), func(i, j int) {
 		slice[i], slice[j] = slice[j], slice[i]
+	})
+}
+
+// Reverse will reverse the order of all elements in the slice using a swap
+// function that should swap two elements in the slice.
+func Reverse(length int, swap func(i, j int)) {
+	for i, j := 0, length-1; i < length/2; i, j = i+1, j-1 {
+		swap(i, j)
 	}
 }

--- a/internal/slices/slices_test.go
+++ b/internal/slices/slices_test.go
@@ -1,0 +1,14 @@
+package slices
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReverseStrings(t *testing.T) {
+	slice := []string{"a", "b", "c", "d", "e"}
+	ReverseStrings(slice)
+	want := []string{"e", "d", "c", "b", "a"}
+	assert.Equal(t, want, slice)
+}

--- a/pkg/gitstat/gitstat_test.go
+++ b/pkg/gitstat/gitstat_test.go
@@ -103,3 +103,76 @@ func TestParseRemotes(t *testing.T) {
 		})
 	}
 }
+
+func TestEstimateRepoGroupAndName(t *testing.T) {
+	tests := []struct {
+		name      string
+		origin    Remote
+		wantGroup string
+		wantName  string
+	}{
+		{
+			name:      "empty",
+			origin:    Remote{},
+			wantGroup: "",
+			wantName:  "",
+		},
+		{
+			name:      "github/ssh-path",
+			origin:    newTestRemote("git@github.com:iver-wharf/wharf-cmd.git"),
+			wantGroup: "iver-wharf",
+			wantName:  "wharf-cmd",
+		},
+		{
+			name:      "github/ssh-url",
+			origin:    newTestRemote("ssh://git@github.com/iver-wharf/wharf-cmd.git"),
+			wantGroup: "iver-wharf",
+			wantName:  "wharf-cmd",
+		},
+		{
+			name:      "github/http-no-dotgit",
+			origin:    newTestRemote("http://git@github.com/iver-wharf/wharf-cmd"),
+			wantGroup: "iver-wharf",
+			wantName:  "wharf-cmd",
+		},
+		{
+			name:      "dev.azure.com/ssh-path",
+			origin:    newTestRemote("git@ssh.dev.azure.com:v3/iver-wharf/wharf/wharf-cmd"),
+			wantGroup: "iver-wharf/wharf",
+			wantName:  "wharf-cmd",
+		},
+		{
+			name:      "dev.azure.com/https",
+			origin:    newTestRemote("https://iver-wharf@dev.azure.com/iver-wharf/wharf/_git/wharf-cmd"),
+			wantGroup: "iver-wharf/wharf",
+			wantName:  "wharf-cmd",
+		},
+		{
+			name:      "gitlab/ssh-path",
+			origin:    newTestRemote("git@gitlab.com:iver-wharf/wharf-subgroup/wharf-cmd.git"),
+			wantGroup: "iver-wharf/wharf-subgroup",
+			wantName:  "wharf-cmd",
+		},
+		{
+			name:      "gitlab/https-url",
+			origin:    newTestRemote("https://gitlab.com/iver-wharf/wharf-subgroup/wharf-cmd.git"),
+			wantGroup: "iver-wharf/wharf-subgroup",
+			wantName:  "wharf-cmd",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotGroup, gotName := estimateRepoGroupAndName(tc.origin)
+			assert.Equal(t, tc.wantGroup, gotGroup, "group name")
+			assert.Equal(t, tc.wantName, gotName, "repo name")
+		})
+	}
+}
+
+func newTestRemote(url string) Remote {
+	return Remote{
+		FetchURL: url,
+		PushURL:  url,
+	}
+}

--- a/pkg/varsub/envsource.go
+++ b/pkg/varsub/envsource.go
@@ -1,0 +1,11 @@
+package varsub
+
+import "os"
+
+// EnvSource is a Source implementation that will pull values from
+// environment variables
+type EnvSource struct{}
+
+func (EnvSource) Lookup(name string) (interface{}, bool) {
+	return os.LookupEnv(name)
+}

--- a/pkg/wharfyml/builtins.go
+++ b/pkg/wharfyml/builtins.go
@@ -21,9 +21,9 @@ const (
 // checks depends on your OS.
 //
 // For GNU/Linux:
+// 	/etc/iver-wharf/wharf-cmd/wharf-vars.yml
 // 	$XDG_CONFIG_HOME/iver-wharf/wharf-cmd/wharf-vars.yml
 // 	(if $XDG_CONFIG_HOME is unset) $HOME/.config/iver-wharf/wharf-cmd/wharf-vars.yml
-// 	/etc/iver-wharf/wharf-cmd/wharf-vars.yml
 //
 // For Windows:
 // 	%APPDATA%\iver-wharf\wharf-cmd\wharf-vars.yml

--- a/pkg/wharfyml/builtins.go
+++ b/pkg/wharfyml/builtins.go
@@ -1,0 +1,50 @@
+package wharfyml
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/iver-wharf/wharf-cmd/internal/slices"
+	"github.com/iver-wharf/wharf-cmd/pkg/varsub"
+)
+
+const (
+	builtInVarsConfFile = "wharf-vars.yml"
+	builtInVarsDotfile  = ".wharf-vars.yml"
+)
+
+func ParseBuiltinVars() (varsub.Source, error) {
+	return nil, errors.New("not implemented")
+}
+
+func listPossibleBuiltinVarsFiles(currentDir string) []string {
+	paths := listOSPossibleBuiltInVars()
+
+	confDir, err := os.UserConfigDir()
+	if err == nil {
+		paths = append(paths,
+			filepath.Join(confDir, "iver-wharf", "wharf-cmd", builtInVarsConfFile),
+		)
+	}
+
+	paths = append(paths, listParentDirsPossibleBuiltinVarsFiles(currentDir)...)
+
+	return paths
+}
+
+func listParentDirsPossibleBuiltinVarsFiles(currentDir string) []string {
+	var paths []string
+	for {
+		paths = append(paths, filepath.Join(currentDir, builtInVarsDotfile))
+		prevDir := currentDir
+		currentDir = filepath.Dir(currentDir)
+		if prevDir == currentDir {
+			break
+		}
+	}
+	// We reverse it because we want the path closest to the current dir
+	// to be merged in last into the varsub.Source.
+	slices.ReverseStrings(paths)
+	return paths
+}

--- a/pkg/wharfyml/builtins.go
+++ b/pkg/wharfyml/builtins.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	builtInVarsConfFile = "wharf-vars.yml"
-	builtInVarsDotfile  = ".wharf-vars.yml"
+	builtInVarsFile    = "wharf-vars.yml"
+	builtInVarsDotfile = ".wharf-vars.yml"
 )
 
 func ParseBuiltinVars() (varsub.Source, error) {
@@ -24,7 +24,7 @@ func listPossibleBuiltinVarsFiles(currentDir string) []string {
 	confDir, err := os.UserConfigDir()
 	if err == nil {
 		paths = append(paths,
-			filepath.Join(confDir, "iver-wharf", "wharf-cmd", builtInVarsConfFile),
+			filepath.Join(confDir, "iver-wharf", "wharf-cmd", builtInVarsFile),
 		)
 	}
 

--- a/pkg/wharfyml/builtins_linux.go
+++ b/pkg/wharfyml/builtins_linux.go
@@ -1,7 +1,10 @@
 package wharfyml
 
-func listOSPossibleBuiltInVars() []string {
-	return []string{
-		"/etc/iver-wharf/wharf-cmd/" + builtInVarsFile,
+func listOSPossibleVarsFiles() []varFile {
+	return []varFile{
+		{
+			path:   "/etc/iver-wharf/wharf-cmd/" + builtInVarsFile,
+			source: varFileSourceConfigDir,
+		},
 	}
 }

--- a/pkg/wharfyml/builtins_linux.go
+++ b/pkg/wharfyml/builtins_linux.go
@@ -1,10 +1,10 @@
 package wharfyml
 
-func listOSPossibleVarsFiles() []varFile {
-	return []varFile{
+func listOSPossibleVarsFiles() []VarFile {
+	return []VarFile{
 		{
-			path:   "/etc/iver-wharf/wharf-cmd/" + builtInVarsFile,
-			source: varFileSourceConfigDir,
+			Path: "/etc/iver-wharf/wharf-cmd/" + builtInVarsFile,
+			Kind: VarFileKindConfigDir,
 		},
 	}
 }

--- a/pkg/wharfyml/builtins_linux.go
+++ b/pkg/wharfyml/builtins_linux.go
@@ -1,0 +1,7 @@
+package wharfyml
+
+func listOSPossibleBuiltInVars() []string {
+	return []string{
+		"/etc/iver-wharf/wharf-cmd/" + builtInVarsConfFile,
+	}
+}

--- a/pkg/wharfyml/builtins_linux.go
+++ b/pkg/wharfyml/builtins_linux.go
@@ -2,6 +2,6 @@ package wharfyml
 
 func listOSPossibleBuiltInVars() []string {
 	return []string{
-		"/etc/iver-wharf/wharf-cmd/" + builtInVarsConfFile,
+		"/etc/iver-wharf/wharf-cmd/" + builtInVarsFile,
 	}
 }

--- a/pkg/wharfyml/builtins_other.go
+++ b/pkg/wharfyml/builtins_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+// +build !linux
+
+package wharfyml
+
+func listOSPossibleBuiltInVars() []string {
+	return nil
+}

--- a/pkg/wharfyml/builtins_other.go
+++ b/pkg/wharfyml/builtins_other.go
@@ -3,6 +3,6 @@
 
 package wharfyml
 
-func listOSPossibleBuiltInVars() []string {
+func listOSPossibleVarsFiles() []varFile {
 	return nil
 }

--- a/pkg/wharfyml/builtins_test.go
+++ b/pkg/wharfyml/builtins_test.go
@@ -6,6 +6,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type testVarSource struct{}
+
+func (testVarSource) Lookup(name string) (interface{}, bool) {
+	switch name {
+	case "REPO_GROUP":
+		return "iver-wharf", true
+	case "REPO_NAME":
+		return "wharf-cmd", true
+	case "REG_URL":
+		return "http://harbor.example.com", true
+	case "CHART_REPO":
+		return "http://harbor.example.com", true
+	default:
+		return nil, false
+	}
+}
+
 func TestListParentDirsPossibleBuiltinVarsFiles(t *testing.T) {
 	currentDir := "/home/root/repos/my-repo"
 	varFiles := listParentDirsPossibleVarsFiles(currentDir)

--- a/pkg/wharfyml/builtins_test.go
+++ b/pkg/wharfyml/builtins_test.go
@@ -18,15 +18,15 @@ func TestListParentDirsPossibleBuiltinVarsFiles(t *testing.T) {
 	}
 	got := make([]string, len(varFiles))
 	for i, f := range varFiles {
-		got[i] = f.path
+		got[i] = f.Path
 	}
 	assert.Equal(t, want, got)
 }
 
 func TestVarFilePrettyPath(t *testing.T) {
 	currentDir := "/home/root/repos/my-repo"
-	file := varFile{path: "/home/root/.wharf-vars.yml", source: varFileSourceParentDir}
+	file := VarFile{Path: "/home/root/.wharf-vars.yml", Kind: VarFileKindParentDir}
 	want := "../../.wharf-vars.yml"
-	got := file.prettyPath(currentDir)
+	got := file.PrettyPath(currentDir)
 	assert.Equal(t, want, got)
 }

--- a/pkg/wharfyml/builtins_test.go
+++ b/pkg/wharfyml/builtins_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestListParentDirsPossibleBuiltinVarsFiles(t *testing.T) {
 	currentDir := "/home/root/repos/my-repo"
-	got := listParentDirsPossibleBuiltinVarsFiles(currentDir)
+	got := listParentDirsPossibleVarsFiles(currentDir)
 	want := []string{
 		"/.wharf-vars.yml",
 		"/home/.wharf-vars.yml",

--- a/pkg/wharfyml/builtins_test.go
+++ b/pkg/wharfyml/builtins_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestListParentDirsPossibleBuiltinVarsFiles(t *testing.T) {
 	currentDir := "/home/root/repos/my-repo"
-	got := listParentDirsPossibleVarsFiles(currentDir)
+	varFiles := listParentDirsPossibleVarsFiles(currentDir)
 	want := []string{
 		"/.wharf-vars.yml",
 		"/home/.wharf-vars.yml",
@@ -16,5 +16,17 @@ func TestListParentDirsPossibleBuiltinVarsFiles(t *testing.T) {
 		"/home/root/repos/.wharf-vars.yml",
 		"/home/root/repos/my-repo/.wharf-vars.yml",
 	}
+	got := make([]string, len(varFiles))
+	for i, f := range varFiles {
+		got[i] = f.path
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestVarFilePrettyPath(t *testing.T) {
+	currentDir := "/home/root/repos/my-repo"
+	file := varFile{path: "/home/root/.wharf-vars.yml", source: varFileSourceParentDir}
+	want := "../../.wharf-vars.yml"
+	got := file.prettyPath(currentDir)
 	assert.Equal(t, want, got)
 }

--- a/pkg/wharfyml/builtins_test.go
+++ b/pkg/wharfyml/builtins_test.go
@@ -1,0 +1,20 @@
+package wharfyml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListParentDirsPossibleBuiltinVarsFiles(t *testing.T) {
+	currentDir := "/home/root/repos/my-repo"
+	got := listParentDirsPossibleBuiltinVarsFiles(currentDir)
+	want := []string{
+		"/.wharf-vars.yml",
+		"/home/.wharf-vars.yml",
+		"/home/root/.wharf-vars.yml",
+		"/home/root/repos/.wharf-vars.yml",
+		"/home/root/repos/my-repo/.wharf-vars.yml",
+	}
+	assert.Equal(t, want, got)
+}

--- a/pkg/wharfyml/definition.go
+++ b/pkg/wharfyml/definition.go
@@ -97,7 +97,7 @@ func visitDefStageNodes(nodes []mapItem, source varsub.Source) (stages []Stage, 
 			errSlice.add(err)
 			continue
 		}
-		stage, errs := visitStageNode(n.key, stageNode)
+		stage, errs := visitStageNode(n.key, stageNode, source)
 		stages = append(stages, stage)
 		errSlice.add(wrapPathErrorSlice(errs, n.key.value)...)
 	}

--- a/pkg/wharfyml/magicstrings.go
+++ b/pkg/wharfyml/magicstrings.go
@@ -1,6 +1,10 @@
 package wharfyml
 
 const (
+	// Map keys in .wharf-ci.yml
 	propInputs       = "inputs"
 	propEnvironments = "environments"
+
+	// Map keys in .wharf-vars.yml
+	propVars = "vars"
 )

--- a/pkg/wharfyml/nodemapparser.go
+++ b/pkg/wharfyml/nodemapparser.go
@@ -182,7 +182,7 @@ func (p nodeMapParser) readFromVarSubForOther(
 	if _, ok := p.nodes[nodeKey]; ok {
 		return nil
 	}
-	value, ok := source.Lookup(varLookup)
+	value, ok := safeLookupVar(source, varLookup)
 	if !ok {
 		return wrapPosErrorNode(fmt.Errorf(
 			"%w: need %s or %q to construct %q",
@@ -201,7 +201,7 @@ func (p nodeMapParser) readFromVarSubForOther(
 
 func (p nodeMapParser) lookupFromVarSubForOther(
 	varLookup, other string, source varsub.Source) (*yaml.Node, error) {
-	repoNameVar, ok := source.Lookup(varLookup)
+	repoNameVar, ok := safeLookupVar(source, varLookup)
 	if !ok {
 		err := fmt.Errorf("%w: need %s to construct %q",
 			ErrMissingBuiltinVar, varLookup, other)
@@ -214,4 +214,11 @@ func (p nodeMapParser) lookupFromVarSubForOther(
 		return nil, wrapPosErrorNode(err, p.parent)
 	}
 	return newNode, nil
+}
+
+func safeLookupVar(source varsub.Source, name string) (interface{}, bool) {
+	if source == nil {
+		return nil, false
+	}
+	return source.Lookup(name)
 }

--- a/pkg/wharfyml/parse_test.go
+++ b/pkg/wharfyml/parse_test.go
@@ -56,7 +56,7 @@ myStage2:
   myKubectlStep:
     kubectl:
       file: deploy/pod.yaml
-`), Args{Env: "myEnvA"})
+`), Args{Env: "myEnvA", VarSource: testVarSource{}})
 	requireNoErr(t, errs)
 
 	assert.Len(t, got.Inputs, 4)
@@ -140,7 +140,7 @@ environments:
   myEnv:
     myStr: !!str 123
     myInt: !!int 123
-`), Args{})
+`), Args{VarSource: testVarSource{}})
 	requireNoErr(t, errs)
 	myEnv, ok := def.Envs["myEnv"]
 	require.True(t, ok, "myEnv environment exists")
@@ -156,7 +156,7 @@ myStage1: &reused
     helm-package: {}
 
 myStage2: *reused
-`), Args{})
+`), Args{VarSource: testVarSource{}})
 	requireNoErr(t, errs)
 	require.Len(t, def.Stages, 2)
 	assert.Equal(t, "myStage1", def.Stages[0].Name, "stage 1 name")
@@ -178,7 +178,7 @@ myStage2:
   <<: *reused
   myOtherStep:
     helm-package: {}
-`), Args{})
+`), Args{VarSource: testVarSource{}})
 	requireNoErr(t, errs)
 	require.Len(t, def.Stages, 2)
 	assert.Equal(t, "myStage1", def.Stages[0].Name, "stage 1 name")
@@ -230,7 +230,7 @@ C:
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, errs := Parse(strings.NewReader(tc.input), Args{})
+			got, errs := Parse(strings.NewReader(tc.input), Args{VarSource: testVarSource{}})
 			require.Empty(t, errs)
 			var gotOrder []string
 			for _, s := range got.Stages {
@@ -276,7 +276,7 @@ myStage:
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, errs := Parse(strings.NewReader(tc.input), Args{})
+			got, errs := Parse(strings.NewReader(tc.input), Args{VarSource: testVarSource{}})
 			requireNoErr(t, errs)
 			require.Len(t, got.Stages, 1)
 			var gotOrder []string

--- a/pkg/wharfyml/stage.go
+++ b/pkg/wharfyml/stage.go
@@ -3,6 +3,7 @@ package wharfyml
 import (
 	"errors"
 
+	"github.com/iver-wharf/wharf-cmd/pkg/varsub"
 	"gopkg.in/yaml.v3"
 )
 
@@ -21,7 +22,7 @@ type Stage struct {
 	Steps   []Step
 }
 
-func visitStageNode(nameNode strNode, node *yaml.Node) (stage Stage, errSlice Errors) {
+func visitStageNode(nameNode strNode, node *yaml.Node, source varsub.Source) (stage Stage, errSlice Errors) {
 	stage.Pos = newPosNode(node)
 	stage.Name = nameNode.value
 	nodes, errs := visitMapSlice(node)
@@ -38,7 +39,7 @@ func visitStageNode(nameNode strNode, node *yaml.Node) (stage Stage, errSlice Er
 			stage.Envs = envs
 			errSlice.add(wrapPathErrorSlice(errs, propEnvironments)...)
 		default:
-			step, errs := visitStepNode(stepNode.key, stepNode.value)
+			step, errs := visitStepNode(stepNode.key, stepNode.value, source)
 			stage.Steps = append(stage.Steps, step)
 			errSlice.add(wrapPathErrorSlice(errs, stepNode.key.value)...)
 		}

--- a/pkg/wharfyml/stage_test.go
+++ b/pkg/wharfyml/stage_test.go
@@ -7,17 +7,20 @@ import (
 )
 
 func TestVisitStage_ErrIfNotMap(t *testing.T) {
-	_, errs := visitStageNode(getKeyedNode(t, `myStage: 123`))
+	key, node := getKeyedNode(t, `myStage: 123`)
+	_, errs := visitStageNode(key, node, nil)
 	requireContainsErr(t, errs, ErrInvalidFieldType)
 }
 
 func TestVisitStage_ErrIfEmptyMap(t *testing.T) {
-	_, errs := visitStageNode(getKeyedNode(t, `myStage: {}`))
+	key, node := getKeyedNode(t, `myStage: {}`)
+	_, errs := visitStageNode(key, node, nil)
 	requireContainsErr(t, errs, ErrStageEmpty)
 }
 
 func TestVisitStage_Name(t *testing.T) {
-	stage, errs := visitStageNode(getKeyedNode(t, `myStage: {}`))
+	key, node := getKeyedNode(t, `myStage: {}`)
+	stage, errs := visitStageNode(key, node, nil)
 	if len(errs) > 0 {
 		t.Logf("errs: %v", errs)
 	}

--- a/pkg/wharfyml/step.go
+++ b/pkg/wharfyml/step.go
@@ -3,6 +3,7 @@ package wharfyml
 import (
 	"errors"
 
+	"github.com/iver-wharf/wharf-cmd/pkg/varsub"
 	"gopkg.in/yaml.v3"
 )
 
@@ -19,7 +20,7 @@ type Step struct {
 	Type StepType
 }
 
-func visitStepNode(name strNode, node *yaml.Node) (step Step, errSlice Errors) {
+func visitStepNode(name strNode, node *yaml.Node, source varsub.Source) (step Step, errSlice Errors) {
 	step.Pos = newPosNode(node)
 	step.Name = name.value
 	nodes, errs := visitMapSlice(node)
@@ -33,7 +34,8 @@ func visitStepNode(name strNode, node *yaml.Node) (step Step, errSlice Errors) {
 		// Continue, its not a fatal issue
 	}
 	for _, stepTypeNode := range nodes {
-		stepType, errs := visitStepTypeNode(stepTypeNode.key, stepTypeNode.value)
+		stepType, errs := visitStepTypeNode(
+			stepTypeNode.key, stepTypeNode.value, source)
 		step.Type = stepType
 		if stepType != nil {
 			errSlice.add(wrapPathErrorSlice(errs, stepType.StepTypeName())...)

--- a/pkg/wharfyml/step.go
+++ b/pkg/wharfyml/step.go
@@ -35,7 +35,7 @@ func visitStepNode(name strNode, node *yaml.Node, source varsub.Source) (step St
 	}
 	for _, stepTypeNode := range nodes {
 		stepType, errs := visitStepTypeNode(
-			stepTypeNode.key, stepTypeNode.value, source)
+			name.value, stepTypeNode.key, stepTypeNode.value, source)
 		step.Type = stepType
 		if stepType != nil {
 			errSlice.add(wrapPathErrorSlice(errs, stepType.StepTypeName())...)

--- a/pkg/wharfyml/step_test.go
+++ b/pkg/wharfyml/step_test.go
@@ -7,29 +7,33 @@ import (
 )
 
 func TestVisitStep_ErrIfNotMap(t *testing.T) {
-	_, errs := visitStepNode(getKeyedNode(t, `myStep: 123`))
+	key, node := getKeyedNode(t, `myStep: 123`)
+	_, errs := visitStepNode(key, node, nil)
 	requireContainsErr(t, errs, ErrInvalidFieldType)
 }
 
 func TestVisitStep_ErrIfEmpty(t *testing.T) {
-	_, errs := visitStepNode(getKeyedNode(t, `myStep: {}`))
+	key, node := getKeyedNode(t, `myStep: {}`)
+	_, errs := visitStepNode(key, node, nil)
 	requireContainsErr(t, errs, ErrStepEmpty)
 }
 
 func TestVisitStep_ErrIfMultipleStepTypes(t *testing.T) {
-	_, errs := visitStepNode(getKeyedNode(t, `
+	key, node := getKeyedNode(t, `
 myStep:
   container: {}
   docker: {}
-`))
+`)
+	_, errs := visitStepNode(key, node, nil)
 	requireContainsErr(t, errs, ErrStepMultipleStepTypes)
 }
 
 func TestVisitStep_Name(t *testing.T) {
-	step, errs := visitStepNode(getKeyedNode(t, `
+	key, node := getKeyedNode(t, `
 myStep:
   helm-package: {}
-`))
+`)
+	step, errs := visitStepNode(key, node, nil)
 	if len(errs) > 0 {
 		t.Logf("errs: %v", errs)
 	}

--- a/pkg/wharfyml/steptype.go
+++ b/pkg/wharfyml/steptype.go
@@ -75,8 +75,9 @@ func (v stepTypeVisitor) visitStepTypeValueNode(stepName string, node *yaml.Node
 	return stepType, errSlice
 }
 
-func getStepTypeMeta(p nodeMapParser) StepTypeMeta {
+func getStepTypeMeta(p nodeMapParser, stepName string) StepTypeMeta {
 	return StepTypeMeta{
+		StepName: stepName,
 		Source:   p.parentPos(),
 		FieldPos: p.positions,
 	}

--- a/pkg/wharfyml/steptype.go
+++ b/pkg/wharfyml/steptype.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/iver-wharf/wharf-cmd/pkg/varsub"
 	"gopkg.in/yaml.v3"
 )
 
@@ -23,12 +24,12 @@ type StepTypeMeta struct {
 	FieldPos map[string]Pos
 }
 
-func visitStepTypeNode(key strNode, node *yaml.Node) (StepType, Errors) {
+func visitStepTypeNode(key strNode, node *yaml.Node, source varsub.Source) (StepType, Errors) {
 	visitor, err := visitStepTypeKeyNode(key)
 	if err != nil {
 		return nil, Errors{err}
 	}
-	return visitor.visitStepTypeValueNode(node)
+	return visitor.visitStepTypeValueNode(node, source)
 }
 
 func visitStepTypeKeyNode(key strNode) (stepTypeVisitor, error) {
@@ -57,16 +58,16 @@ func visitStepTypeKeyNode(key strNode) (stepTypeVisitor, error) {
 
 type stepTypeVisitor struct {
 	keyNode   *yaml.Node
-	visitNode func(nodeMapParser) (StepType, Errors)
+	visitNode func(p nodeMapParser, source varsub.Source) (StepType, Errors)
 }
 
-func (v stepTypeVisitor) visitStepTypeValueNode(node *yaml.Node) (StepType, Errors) {
+func (v stepTypeVisitor) visitStepTypeValueNode(node *yaml.Node, source varsub.Source) (StepType, Errors) {
 	var errSlice Errors
 	m, errs := visitMap(node)
 	errSlice.add(errs...)
 
 	parser := newNodeMapParser(v.keyNode, m)
-	stepType, errs := v.visitNode(parser)
+	stepType, errs := v.visitNode(parser, source)
 	errSlice.add(errs...)
 
 	return stepType, errSlice

--- a/pkg/wharfyml/steptype_container.go
+++ b/pkg/wharfyml/steptype_container.go
@@ -1,5 +1,7 @@
 package wharfyml
 
+import "github.com/iver-wharf/wharf-cmd/pkg/varsub"
+
 // StepContainer represents a step type for running commands inside a Docker
 // container.
 type StepContainer struct {
@@ -21,7 +23,7 @@ type StepContainer struct {
 // StepTypeName returns the name of this step type.
 func (StepContainer) StepTypeName() string { return "container" }
 
-func (s StepContainer) visitStepTypeNode(p nodeMapParser) (StepType, Errors) {
+func (s StepContainer) visitStepTypeNode(p nodeMapParser, source varsub.Source) (StepType, Errors) {
 	s.Meta = getStepTypeMeta(p)
 
 	s.OS = "linux"

--- a/pkg/wharfyml/steptype_container.go
+++ b/pkg/wharfyml/steptype_container.go
@@ -24,7 +24,7 @@ type StepContainer struct {
 func (StepContainer) StepTypeName() string { return "container" }
 
 func (s StepContainer) visitStepTypeNode(stepName string, p nodeMapParser, source varsub.Source) (StepType, Errors) {
-	s.Meta = getStepTypeMeta(p)
+	s.Meta = getStepTypeMeta(p, stepName)
 
 	s.OS = "linux"
 	s.Shell = "/bin/sh"

--- a/pkg/wharfyml/steptype_container.go
+++ b/pkg/wharfyml/steptype_container.go
@@ -23,7 +23,7 @@ type StepContainer struct {
 // StepTypeName returns the name of this step type.
 func (StepContainer) StepTypeName() string { return "container" }
 
-func (s StepContainer) visitStepTypeNode(p nodeMapParser, source varsub.Source) (StepType, Errors) {
+func (s StepContainer) visitStepTypeNode(stepName string, p nodeMapParser, source varsub.Source) (StepType, Errors) {
 	s.Meta = getStepTypeMeta(p)
 
 	s.OS = "linux"

--- a/pkg/wharfyml/steptype_docker.go
+++ b/pkg/wharfyml/steptype_docker.go
@@ -34,7 +34,7 @@ type StepDocker struct {
 func (StepDocker) StepTypeName() string { return "docker" }
 
 func (s StepDocker) visitStepTypeNode(stepName string, p nodeMapParser, source varsub.Source) (StepType, Errors) {
-	s.Meta = getStepTypeMeta(p)
+	s.Meta = getStepTypeMeta(p, stepName)
 
 	s.Name = stepName
 	s.Secret = "gitlab-registry"

--- a/pkg/wharfyml/steptype_docker.go
+++ b/pkg/wharfyml/steptype_docker.go
@@ -1,6 +1,11 @@
 package wharfyml
 
-import "github.com/iver-wharf/wharf-cmd/pkg/varsub"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/iver-wharf/wharf-cmd/pkg/varsub"
+)
 
 // StepDocker represents a step type for building and pushing Docker images.
 type StepDocker struct {
@@ -28,19 +33,106 @@ type StepDocker struct {
 // StepTypeName returns the name of this step type.
 func (StepDocker) StepTypeName() string { return "docker" }
 
-func (s StepDocker) visitStepTypeNode(p nodeMapParser, source varsub.Source) (StepType, Errors) {
+func (s StepDocker) visitStepTypeNode(stepName string, p nodeMapParser, source varsub.Source) (StepType, Errors) {
 	s.Meta = getStepTypeMeta(p)
 
-	s.Destination = ""  // TODO: default to "${registry}/${group}/${REPO_NAME}/${step_name}"
-	s.Name = ""         // TODO: default to "${step_name}"
-	s.Group = ""        // TODO: default to "${REPO_GROUP}"
-	s.Registry = ""     // TODO: default to "${REG_URL}"
-	s.AppendCert = true // TODO: default to true if REPO_GROUP starts with "default", case insensitive
+	s.Destination = ""
+	s.Name = stepName
 
 	s.Push = true
 	s.Secret = "gitlab-registry"
 
 	var errSlice Errors
+
+	if _, ok := p.nodes["destination"]; !ok {
+		if _, ok := p.nodes["registry"]; !ok {
+			regURL, ok := source.Lookup("REG_URL")
+			if !ok {
+				errSlice.add(wrapPosErrorNode(fmt.Errorf(
+					"%w: need REG_URL or 'registry' to construct 'destination'",
+					ErrMissingBuiltinVar),
+					p.parent))
+			} else {
+				newNode, err := newNodeWithValue(p.parent, regURL)
+				if err != nil {
+					errSlice.add(wrapPosErrorNode(fmt.Errorf(
+						"read REG_URL to construct 'destination': %w", err),
+						p.parent))
+				} else {
+					p.nodes["registry"] = newNode
+				}
+			}
+		}
+
+		if _, ok := p.nodes["group"]; !ok {
+			repoGroup, ok := source.Lookup("REPO_GROUP")
+			if !ok {
+				errSlice.add(wrapPosErrorNode(fmt.Errorf(
+					"%w: need REPO_GROUP or 'group' to construct 'destination'",
+					ErrMissingBuiltinVar),
+					p.parent))
+			} else {
+				newNode, err := newNodeWithValue(p.parent, repoGroup)
+				if err != nil {
+					errSlice.add(wrapPosErrorNode(fmt.Errorf(
+						"read REPO_GROUP to construct 'destination': %w", err),
+						p.parent))
+				} else {
+					p.nodes["group"] = newNode
+				}
+			}
+		}
+
+		repoNameVar, ok := source.Lookup("REPO_NAME")
+		if !ok {
+			errSlice.add(wrapPosErrorNode(fmt.Errorf(
+				"%w: need REPO_NAME to construct 'destination'",
+				ErrMissingBuiltinVar),
+				p.parent))
+		} else {
+			newNode, err := newNodeWithValue(p.parent, repoNameVar)
+			errSlice.add(wrapPosErrorNode(fmt.Errorf(
+				"read REPO_NAME to construct 'destination': %w", err),
+				p.parent))
+			// __repoName isn't a real field, but we're setting it to abuse
+			// p.unmarshalString()
+			p.nodes["__repoName"] = newNode
+		}
+
+		var repoName string
+		errSlice.addNonNils(
+			p.unmarshalString("registry", &s.Registry),
+			p.unmarshalString("group", &s.Group),
+			p.unmarshalString("name", &s.Name),
+			p.unmarshalString("__repoName", &repoName),
+		)
+		if len(errSlice) == 0 {
+			s.Destination = fmt.Sprintf("%s/%s/%s/%s",
+				s.Registry, s.Group, repoName, s.Name,
+			)
+			// default to "${registry}/${group}/${REPO_NAME}/${step_name}"
+		}
+	}
+
+	if _, ok := p.nodes["group"]; !ok {
+		repoGroup, ok := source.Lookup("REPO_GROUP")
+		if ok {
+			newNode, err := newNodeWithValue(p.parent, repoGroup)
+			if err != nil {
+				errSlice.add(wrapPosErrorNode(fmt.Errorf(
+					"read REPO_GROUP to construct 'destination': %w", err),
+					p.parent))
+			} else {
+				p.nodes["group"] = newNode
+				err := p.unmarshalString("group", &s.Group)
+				if err != nil {
+					errSlice.add(err)
+				} else if strings.HasPrefix(strings.ToLower(s.Group), "default") {
+					s.AppendCert = true
+				}
+			}
+		}
+	}
 
 	// Unmarshalling
 	errSlice.addNonNils(
@@ -48,10 +140,8 @@ func (s StepDocker) visitStepTypeNode(p nodeMapParser, source varsub.Source) (St
 		p.unmarshalString("tag", &s.Tag),
 		p.unmarshalString("destination", &s.Destination),
 		p.unmarshalString("name", &s.Name),
-		p.unmarshalString("group", &s.Group),
 		p.unmarshalString("context", &s.Context),
 		p.unmarshalString("secret", &s.Secret),
-		p.unmarshalString("registry", &s.Registry),
 		p.unmarshalBool("append-cert", &s.AppendCert),
 		p.unmarshalBool("push", &s.Push),
 		p.unmarshalString("secretName", &s.SecretName),

--- a/pkg/wharfyml/steptype_docker.go
+++ b/pkg/wharfyml/steptype_docker.go
@@ -1,5 +1,7 @@
 package wharfyml
 
+import "github.com/iver-wharf/wharf-cmd/pkg/varsub"
+
 // StepDocker represents a step type for building and pushing Docker images.
 type StepDocker struct {
 	// Step type metadata
@@ -26,7 +28,7 @@ type StepDocker struct {
 // StepTypeName returns the name of this step type.
 func (StepDocker) StepTypeName() string { return "docker" }
 
-func (s StepDocker) visitStepTypeNode(p nodeMapParser) (StepType, Errors) {
+func (s StepDocker) visitStepTypeNode(p nodeMapParser, source varsub.Source) (StepType, Errors) {
 	s.Meta = getStepTypeMeta(p)
 
 	s.Destination = ""  // TODO: default to "${registry}/${group}/${REPO_NAME}/${step_name}"

--- a/pkg/wharfyml/steptype_helm.go
+++ b/pkg/wharfyml/steptype_helm.go
@@ -25,7 +25,7 @@ type StepHelm struct {
 // StepTypeName returns the name of this step type.
 func (StepHelm) StepTypeName() string { return "helm" }
 
-func (s StepHelm) visitStepTypeNode(p nodeMapParser, source varsub.Source) (StepType, Errors) {
+func (s StepHelm) visitStepTypeNode(stepName string, p nodeMapParser, source varsub.Source) (StepType, Errors) {
 	s.Meta = getStepTypeMeta(p)
 
 	s.Repo = "" // TODO: default to "${CHART_REPO}/${REPO_GROUP}"

--- a/pkg/wharfyml/steptype_helm.go
+++ b/pkg/wharfyml/steptype_helm.go
@@ -30,7 +30,7 @@ type StepHelm struct {
 func (StepHelm) StepTypeName() string { return "helm" }
 
 func (s StepHelm) visitStepTypeNode(stepName string, p nodeMapParser, source varsub.Source) (StepType, Errors) {
-	s.Meta = getStepTypeMeta(p)
+	s.Meta = getStepTypeMeta(p, stepName)
 
 	s.Cluster = "kubectl-config"
 	s.HelmVersion = "v2.14.1"

--- a/pkg/wharfyml/steptype_helm.go
+++ b/pkg/wharfyml/steptype_helm.go
@@ -1,5 +1,7 @@
 package wharfyml
 
+import "github.com/iver-wharf/wharf-cmd/pkg/varsub"
+
 // StepHelm represents a step type for installing a Helm chart into a Kubernetes
 // cluster.
 type StepHelm struct {
@@ -23,7 +25,7 @@ type StepHelm struct {
 // StepTypeName returns the name of this step type.
 func (StepHelm) StepTypeName() string { return "helm" }
 
-func (s StepHelm) visitStepTypeNode(p nodeMapParser) (StepType, Errors) {
+func (s StepHelm) visitStepTypeNode(p nodeMapParser, source varsub.Source) (StepType, Errors) {
 	s.Meta = getStepTypeMeta(p)
 
 	s.Repo = "" // TODO: default to "${CHART_REPO}/${REPO_GROUP}"

--- a/pkg/wharfyml/steptype_helmpackage.go
+++ b/pkg/wharfyml/steptype_helmpackage.go
@@ -22,7 +22,7 @@ type StepHelmPackage struct {
 func (StepHelmPackage) StepTypeName() string { return "helm-package" }
 
 func (s StepHelmPackage) visitStepTypeNode(stepName string, p nodeMapParser, source varsub.Source) (StepType, Errors) {
-	s.Meta = getStepTypeMeta(p)
+	s.Meta = getStepTypeMeta(p, stepName)
 
 	var errSlice Errors
 

--- a/pkg/wharfyml/steptype_helmpackage.go
+++ b/pkg/wharfyml/steptype_helmpackage.go
@@ -17,7 +17,7 @@ type StepHelmPackage struct {
 // StepTypeName returns the name of this step type.
 func (StepHelmPackage) StepTypeName() string { return "helm-package" }
 
-func (s StepHelmPackage) visitStepTypeNode(p nodeMapParser, source varsub.Source) (StepType, Errors) {
+func (s StepHelmPackage) visitStepTypeNode(stepName string, p nodeMapParser, source varsub.Source) (StepType, Errors) {
 	s.Meta = getStepTypeMeta(p)
 
 	s.Destination = "" // TODO: default to "${CHART_REPO}/${REPO_GROUP}"

--- a/pkg/wharfyml/steptype_helmpackage.go
+++ b/pkg/wharfyml/steptype_helmpackage.go
@@ -1,5 +1,7 @@
 package wharfyml
 
+import "github.com/iver-wharf/wharf-cmd/pkg/varsub"
+
 // StepHelmPackage represents a step type for building and uploading a Helm
 // chart to a chart registry.
 type StepHelmPackage struct {
@@ -15,7 +17,7 @@ type StepHelmPackage struct {
 // StepTypeName returns the name of this step type.
 func (StepHelmPackage) StepTypeName() string { return "helm-package" }
 
-func (s StepHelmPackage) visitStepTypeNode(p nodeMapParser) (StepType, Errors) {
+func (s StepHelmPackage) visitStepTypeNode(p nodeMapParser, source varsub.Source) (StepType, Errors) {
 	s.Meta = getStepTypeMeta(p)
 
 	s.Destination = "" // TODO: default to "${CHART_REPO}/${REPO_GROUP}"

--- a/pkg/wharfyml/steptype_helmpackage.go
+++ b/pkg/wharfyml/steptype_helmpackage.go
@@ -1,6 +1,10 @@
 package wharfyml
 
-import "github.com/iver-wharf/wharf-cmd/pkg/varsub"
+import (
+	"fmt"
+
+	"github.com/iver-wharf/wharf-cmd/pkg/varsub"
+)
 
 // StepHelmPackage represents a step type for building and uploading a Helm
 // chart to a chart registry.
@@ -20,9 +24,19 @@ func (StepHelmPackage) StepTypeName() string { return "helm-package" }
 func (s StepHelmPackage) visitStepTypeNode(stepName string, p nodeMapParser, source varsub.Source) (StepType, Errors) {
 	s.Meta = getStepTypeMeta(p)
 
-	s.Destination = "" // TODO: default to "${CHART_REPO}/${REPO_GROUP}"
-
 	var errSlice Errors
+
+	if !p.hasNode("destination") {
+		var chartRepo string
+		var repoGroup string
+		errSlice.addNonNils(
+			p.unmarshalStringFromVarSubForOther(
+				"CHART_REPO", "destination", source, &chartRepo),
+			p.unmarshalStringFromVarSubForOther(
+				"REPO_GROUP", "destination", source, &repoGroup),
+		)
+		s.Destination = fmt.Sprintf("%s/%s", chartRepo, repoGroup)
+	}
 
 	// Unmarshalling
 	errSlice.addNonNils(

--- a/pkg/wharfyml/steptype_kubectl.go
+++ b/pkg/wharfyml/steptype_kubectl.go
@@ -23,7 +23,7 @@ type StepKubectl struct {
 func (StepKubectl) StepTypeName() string { return "kubectl" }
 
 func (s StepKubectl) visitStepTypeNode(stepName string, p nodeMapParser, source varsub.Source) (StepType, Errors) {
-	s.Meta = getStepTypeMeta(p)
+	s.Meta = getStepTypeMeta(p, stepName)
 
 	s.Cluster = "kubectl-config"
 	s.Action = "apply"

--- a/pkg/wharfyml/steptype_kubectl.go
+++ b/pkg/wharfyml/steptype_kubectl.go
@@ -1,5 +1,7 @@
 package wharfyml
 
+import "github.com/iver-wharf/wharf-cmd/pkg/varsub"
+
 // StepKubectl represents a step type for running kubectl commands on some
 // Kubernetes manifest files.
 type StepKubectl struct {
@@ -20,7 +22,7 @@ type StepKubectl struct {
 // StepTypeName returns the name of this step type.
 func (StepKubectl) StepTypeName() string { return "kubectl" }
 
-func (s StepKubectl) visitStepTypeNode(p nodeMapParser) (StepType, Errors) {
+func (s StepKubectl) visitStepTypeNode(p nodeMapParser, source varsub.Source) (StepType, Errors) {
 	s.Meta = getStepTypeMeta(p)
 
 	s.Cluster = "kubectl-config"

--- a/pkg/wharfyml/steptype_kubectl.go
+++ b/pkg/wharfyml/steptype_kubectl.go
@@ -22,7 +22,7 @@ type StepKubectl struct {
 // StepTypeName returns the name of this step type.
 func (StepKubectl) StepTypeName() string { return "kubectl" }
 
-func (s StepKubectl) visitStepTypeNode(p nodeMapParser, source varsub.Source) (StepType, Errors) {
+func (s StepKubectl) visitStepTypeNode(stepName string, p nodeMapParser, source varsub.Source) (StepType, Errors) {
 	s.Meta = getStepTypeMeta(p)
 
 	s.Cluster = "kubectl-config"

--- a/pkg/wharfyml/steptype_nugetpackage.go
+++ b/pkg/wharfyml/steptype_nugetpackage.go
@@ -21,7 +21,7 @@ type StepNuGetPackage struct {
 // StepTypeName returns the name of this step type.
 func (StepNuGetPackage) StepTypeName() string { return "nuget-package" }
 
-func (s StepNuGetPackage) visitStepTypeNode(p nodeMapParser, source varsub.Source) (StepType, Errors) {
+func (s StepNuGetPackage) visitStepTypeNode(stepName string, p nodeMapParser, source varsub.Source) (StepType, Errors) {
 	s.Meta = getStepTypeMeta(p)
 
 	var errSlice Errors

--- a/pkg/wharfyml/steptype_nugetpackage.go
+++ b/pkg/wharfyml/steptype_nugetpackage.go
@@ -22,7 +22,7 @@ type StepNuGetPackage struct {
 func (StepNuGetPackage) StepTypeName() string { return "nuget-package" }
 
 func (s StepNuGetPackage) visitStepTypeNode(stepName string, p nodeMapParser, source varsub.Source) (StepType, Errors) {
-	s.Meta = getStepTypeMeta(p)
+	s.Meta = getStepTypeMeta(p, stepName)
 
 	var errSlice Errors
 

--- a/pkg/wharfyml/steptype_nugetpackage.go
+++ b/pkg/wharfyml/steptype_nugetpackage.go
@@ -1,5 +1,7 @@
 package wharfyml
 
+import "github.com/iver-wharf/wharf-cmd/pkg/varsub"
+
 // StepNuGetPackage represents a step type used for building .NET NuGet
 // packages.
 type StepNuGetPackage struct {
@@ -19,7 +21,7 @@ type StepNuGetPackage struct {
 // StepTypeName returns the name of this step type.
 func (StepNuGetPackage) StepTypeName() string { return "nuget-package" }
 
-func (s StepNuGetPackage) visitStepTypeNode(p nodeMapParser) (StepType, Errors) {
+func (s StepNuGetPackage) visitStepTypeNode(p nodeMapParser, source varsub.Source) (StepType, Errors) {
 	s.Meta = getStepTypeMeta(p)
 
 	var errSlice Errors

--- a/pkg/wharfyml/steptype_test.go
+++ b/pkg/wharfyml/steptype_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestVisitStepType_ErrIfNotMap(t *testing.T) {
 	key, node := getKeyedNode(t, `container: 123`)
-	_, errs := visitStepTypeNode("", key, node, nil)
+	_, errs := visitStepTypeNode("", key, node, testVarSource{})
 	requireContainsErr(t, errs, ErrInvalidFieldType)
 }
 
@@ -14,13 +14,13 @@ func TestVisitStepType_ErrIfInvalidField(t *testing.T) {
 	key, node := getKeyedNode(t, `
 container:
   image: [123]`)
-	_, errs := visitStepTypeNode("", key, node, nil)
+	_, errs := visitStepTypeNode("", key, node, testVarSource{})
 	requireContainsErr(t, errs, ErrInvalidFieldType)
 }
 
 func TestVisitStepType_ErrIfMissingRequiredField(t *testing.T) {
 	// in "container" step, "cmds" and "image" are required
 	key, node := getKeyedNode(t, `container: {}`)
-	_, errs := visitStepTypeNode("", key, node, nil)
+	_, errs := visitStepTypeNode("", key, node, testVarSource{})
 	requireContainsErr(t, errs, ErrMissingRequired)
 }

--- a/pkg/wharfyml/steptype_test.go
+++ b/pkg/wharfyml/steptype_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestVisitStepType_ErrIfNotMap(t *testing.T) {
 	key, node := getKeyedNode(t, `container: 123`)
-	_, errs := visitStepTypeNode(key, node, nil)
+	_, errs := visitStepTypeNode(stepName string, key, node, nil)
 	requireContainsErr(t, errs, ErrInvalidFieldType)
 }
 
@@ -14,13 +14,13 @@ func TestVisitStepType_ErrIfInvalidField(t *testing.T) {
 	key, node := getKeyedNode(t, `
 container:
   image: [123]`)
-	_, errs := visitStepTypeNode(key, node, nil)
+	_, errs := visitStepTypeNode(stepName string, key, node, nil)
 	requireContainsErr(t, errs, ErrInvalidFieldType)
 }
 
 func TestVisitStepType_ErrIfMissingRequiredField(t *testing.T) {
 	// in "container" step, "cmds" and "image" are required
 	key, node := getKeyedNode(t, `container: {}`)
-	_, errs := visitStepTypeNode(key, node, nil)
+	_, errs := visitStepTypeNode(stepName string, key, node, nil)
 	requireContainsErr(t, errs, ErrMissingRequired)
 }

--- a/pkg/wharfyml/steptype_test.go
+++ b/pkg/wharfyml/steptype_test.go
@@ -5,19 +5,22 @@ import (
 )
 
 func TestVisitStepType_ErrIfNotMap(t *testing.T) {
-	_, errs := visitStepTypeNode(getKeyedNode(t, `container: 123`))
+	key, node := getKeyedNode(t, `container: 123`)
+	_, errs := visitStepTypeNode(key, node, nil)
 	requireContainsErr(t, errs, ErrInvalidFieldType)
 }
 
 func TestVisitStepType_ErrIfInvalidField(t *testing.T) {
-	_, errs := visitStepTypeNode(getKeyedNode(t, `
+	key, node := getKeyedNode(t, `
 container:
-  image: [123]`))
+  image: [123]`)
+	_, errs := visitStepTypeNode(key, node, nil)
 	requireContainsErr(t, errs, ErrInvalidFieldType)
 }
 
 func TestVisitStepType_ErrIfMissingRequiredField(t *testing.T) {
 	// in "container" step, "cmds" and "image" are required
-	_, errs := visitStepTypeNode(getKeyedNode(t, `container: {}`))
+	key, node := getKeyedNode(t, `container: {}`)
+	_, errs := visitStepTypeNode(key, node, nil)
 	requireContainsErr(t, errs, ErrMissingRequired)
 }

--- a/pkg/wharfyml/steptype_test.go
+++ b/pkg/wharfyml/steptype_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestVisitStepType_ErrIfNotMap(t *testing.T) {
 	key, node := getKeyedNode(t, `container: 123`)
-	_, errs := visitStepTypeNode(stepName string, key, node, nil)
+	_, errs := visitStepTypeNode("", key, node, nil)
 	requireContainsErr(t, errs, ErrInvalidFieldType)
 }
 
@@ -14,13 +14,13 @@ func TestVisitStepType_ErrIfInvalidField(t *testing.T) {
 	key, node := getKeyedNode(t, `
 container:
   image: [123]`)
-	_, errs := visitStepTypeNode(stepName string, key, node, nil)
+	_, errs := visitStepTypeNode("", key, node, nil)
 	requireContainsErr(t, errs, ErrInvalidFieldType)
 }
 
 func TestVisitStepType_ErrIfMissingRequiredField(t *testing.T) {
 	// in "container" step, "cmds" and "image" are required
 	key, node := getKeyedNode(t, `container: {}`)
-	_, errs := visitStepTypeNode(stepName string, key, node, nil)
+	_, errs := visitStepTypeNode("", key, node, nil)
 	requireContainsErr(t, errs, ErrMissingRequired)
 }

--- a/test/.wharf-ci.yml
+++ b/test/.wharf-ci.yml
@@ -29,7 +29,7 @@ needs-cancel:
   long-running:
     container:
       image: alpine:latest
-      cmds: 
+      cmds:
       - sleep infinity
 
   fails:

--- a/test/.wharf-ci.yml
+++ b/test/.wharf-ci.yml
@@ -11,6 +11,13 @@ helm-pack:
     helm-package:
       chart-path: helm-chart
 
+helm-deploy:
+  my-chart:
+    helm:
+      name: my-release
+      chart: lorem
+      namespace: foo
+
 test:
   step1:
     container:


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added builtin vars file listing inside new `pkg/wharfyml/builtins.go` files
- Added `varsub.Source` all the way down to step type parsing inside `pkg/wharfyml`
- Added current dir-evaluating based on where the `.wharf-ci.yml` file is
- Added defaults for steps based on built-in vars
- Added gitstats as `varsub.Source`

## Motivation

There was a big discussion in #55, and this implementation adds what we concluded.

The same conclusions can also be seen in the logs if you get "missing built-in var" error:

```console
$ go run . run -p test/.wharf-ci.yml
[WARN ] Cannot run build due to parsing errors.  errors=3
[WARN ]    4:5   build/my-build/docker: missing built-in var: need REG_URL or "registry" to construct "destination"
[WARN ]   11:5   helm-pack/my-chart/helm-package: missing built-in var: need CHART_REPO to construct "destination"
[WARN ]   16:5   helm-deploy/my-chart/helm: missing built-in var: need CHART_REPO to construct "repo"
[INFO ] Tip: You can add built-in variables to Wharf in multiple ways.
	
	Wharf look for values in the following files:
	  /etc/iver-wharf/wharf-cmd/wharf-vars.yml
	  ~/.config/iver-wharf/wharf-cmd/wharf-vars.yml
	
	Wharf also looks for:
	  - All ".wharf-vars.yml" in this directory or any parent directory.
	  - Local Git repository and extracts GIT_ and REPO_ variables from it.
	  - Environment variables.
	
	Sample file content:
	  # .wharf-vars.yml
	  vars:
	    REG_URL: http://harbor.example.com
	
[ERROR] failed to parse .wharf-ci.yml
exit status 1
```

This implementation is made so that you could write your .wharf-ci.yml file to bypass all the built-in variables. They are only there to help.

In other words, this makes the `docker.destination` field required, iff `REG_URL`, `REPO_NAME`, and `REPO_GROUP` are undefined. Same deal for other fields of some of the other step types.

Closes #55
