### PR TITLE
Updated to Go v1.18

### DIFF
--- a/.github/workflows/go-format.yml
+++ b/.github/workflows/go-format.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
+          go-version: '1.18'
 
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
 
       - name: Set up gotestfmt
         uses: haveyoudebuggedit/gotestfmt-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - `k8s.io/client-go` from v0.0.0 to v0.23.3 (#8)
   - `sigs.k8s.io/yaml` from v1.1.0 to v1.2.0 (#8)
 
-- Changed Go runtime from v1.13 to v1.17. (#8)
+- Changed Go runtime from v1.13 to v1.18. (#8, #74)
 
 - Changed logging on CLI errors (ex "unknown command") to be more terse. (#34)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 AS build
+FROM golang:1.18 AS build
 WORKDIR /src
 ENV GO111MODULE=on
 COPY . /src

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A command-line interface to run tasks specified in a `.wharf-ci.yml` file.
 
 ## Development
 
-1. Install Go 1.17 or later: <https://golang.org/>
+1. Install Go 1.18 or later: <https://golang.org/>
 
 2. Start hacking with your favorite tool. For example VS Code, GoLand,
    Vim, Emacs, or whatnot.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/iver-wharf/wharf-cmd
 
-go 1.17
+go 1.18
 
 require (
 	github.com/alta/protopatch v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -175,7 +175,6 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
-github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
@@ -699,7 +698,6 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
-github.com/ugorji/go v1.2.7 h1:qYhyWUUd6WbiM+C6JZAUkIJt/1WrjzNHY9+KCIjVqTo=
 github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6M=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
@@ -714,7 +712,6 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -802,7 +799,6 @@ golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.5.0/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
-golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -908,10 +904,8 @@ golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 h1:nhht2DYV/Sn3qOayu8lM+cU1ii9sTLUeBQwQQfUHtrs=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/pkg/resultstore/keyedmutex.go
+++ b/pkg/resultstore/keyedmutex.go
@@ -6,13 +6,13 @@ type keyedMutex struct {
 	m sync.Map
 }
 
-func (k keyedMutex) Lock(key interface{}) {
+func (k keyedMutex) Lock(key any) {
 	val, _ := k.m.LoadOrStore(key, &sync.Mutex{})
 	mutex := val.(*sync.Mutex)
 	mutex.Lock()
 }
 
-func (k keyedMutex) Unlock(key interface{}) {
+func (k keyedMutex) Unlock(key any) {
 	val, ok := k.m.Load(key)
 	if !ok {
 		return

--- a/pkg/varsub/source.go
+++ b/pkg/varsub/source.go
@@ -4,7 +4,7 @@ package varsub
 type Source interface {
 	// Lookup tries to look up a value based on name and returns that value as
 	// well as true on success, or false if the variable was not found.
-	Lookup(name string) (interface{}, bool)
+	Lookup(name string) (any, bool)
 }
 
 // SourceSlice is a slice of variable substution sources that act as a source
@@ -13,7 +13,7 @@ type SourceSlice []Source
 
 // Lookup tries to look up a value based on name and returns that value as
 // well as true on success, or false if the variable was not found.
-func (ss SourceSlice) Lookup(name string) (interface{}, bool) {
+func (ss SourceSlice) Lookup(name string) (any, bool) {
 	for _, s := range ss {
 		val, ok := s.Lookup(name)
 		if ok {
@@ -25,11 +25,11 @@ func (ss SourceSlice) Lookup(name string) (interface{}, bool) {
 
 // SourceMap is a variable substitution source based on a map where it uses the
 // underlying map as the variable source.
-type SourceMap map[string]interface{}
+type SourceMap map[string]any
 
 // Lookup tries to look up a value based on name and returns that value as
 // well as true on success, or false if the variable was not found.
-func (s SourceMap) Lookup(name string) (interface{}, bool) {
+func (s SourceMap) Lookup(name string) (any, bool) {
 	val, ok := s[name]
 	return val, ok
 }

--- a/pkg/varsub/varsub.go
+++ b/pkg/varsub/varsub.go
@@ -27,15 +27,15 @@ var escapedParamPattern = regexp.MustCompile(`%(\s*[\w_\s]*\s*)%`)
 
 // Substitute will replace all variables in the string using the variable
 // substution source. Variables are looked up recursively.
-func Substitute(value string, source Source) (interface{}, error) {
+func Substitute(value string, source Source) (any, error) {
 	return substituteRec(value, source, nil)
 }
 
-func substituteRec(value string, source Source, usedParams []string) (interface{}, error) {
+func substituteRec(value string, source Source, usedParams []string) (any, error) {
 	result := value
 	matches := Matches(value)
 	for _, match := range matches {
-		var matchVal interface{}
+		var matchVal any
 		if match.Name == "%" {
 			matchVal = "${}"
 		} else if escapedParamPattern.MatchString(match.Name) {
@@ -76,7 +76,7 @@ func containsString(slice []string, element string) bool {
 	return false
 }
 
-func stringify(val interface{}) string {
+func stringify(val any) string {
 	switch val := val.(type) {
 	case string:
 		return val

--- a/pkg/varsub/varsub_test.go
+++ b/pkg/varsub/varsub_test.go
@@ -176,7 +176,7 @@ func TestSubstitute_nonStrings(t *testing.T) {
 		name   string
 		source SourceMap
 		value  string
-		want   interface{}
+		want   any
 	}{
 		{
 			name:   "full/bool",
@@ -242,7 +242,7 @@ func TestSubstitute_recursive(t *testing.T) {
 		name   string
 		source SourceMap
 		value  string
-		want   interface{}
+		want   any
 	}{
 		{
 			name: "string",

--- a/pkg/wharfyml/environment.go
+++ b/pkg/wharfyml/environment.go
@@ -16,7 +16,7 @@ var (
 type Env struct {
 	Source Pos
 	Name   string
-	Vars   map[string]interface{}
+	Vars   map[string]any
 }
 
 // EnvRef is a reference to an environments definition. Used in stages.
@@ -41,7 +41,7 @@ func visitDocEnvironmentsNode(node *yaml.Node) (map[string]Env, Errors) {
 func visitEnvironmentNode(nameNode strNode, node *yaml.Node) (env Env, errSlice Errors) {
 	env = Env{
 		Name:   nameNode.value,
-		Vars:   make(map[string]interface{}),
+		Vars:   make(map[string]any),
 		Source: newPosNode(node),
 	}
 	nodes, errs := visitMapSlice(node)
@@ -56,7 +56,7 @@ func visitEnvironmentNode(nameNode strNode, node *yaml.Node) (env Env, errSlice 
 	return
 }
 
-func visitEnvironmentVariableNode(node *yaml.Node) (interface{}, error) {
+func visitEnvironmentVariableNode(node *yaml.Node) (any, error) {
 	if err := verifyKind(node, "string, boolean, or number", yaml.ScalarNode); err != nil {
 		return nil, err
 	}

--- a/pkg/wharfyml/environment_test.go
+++ b/pkg/wharfyml/environment_test.go
@@ -65,7 +65,7 @@ myEnv:
   myBool: true
 `))
 	requireNotContainsErr(t, errs, ErrInvalidFieldType)
-	want := map[string]interface{}{
+	want := map[string]any{
 		"myIntNeg": -123,
 		"myIntPos": 123,
 		"myFloat":  456.789,

--- a/pkg/wharfyml/varsub.go
+++ b/pkg/wharfyml/varsub.go
@@ -47,7 +47,7 @@ func varSubStringNode(str strNode, source varsub.Source) (*yaml.Node, error) {
 	return newNodeWithValue(str.node, val)
 }
 
-func newNodeWithValue(node *yaml.Node, val interface{}) (*yaml.Node, error) {
+func newNodeWithValue(node *yaml.Node, val any) (*yaml.Node, error) {
 	clone := *node
 	clone.Kind = yaml.ScalarNode
 	switch val := val.(type) {


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Updated Go runtime to v1.18 :tada:
- Changed from `interface{}` to `any`
- Ran `go mod tidy`

## Motivation

1. Stay up to date
2. LET'S PLAY WITH THE NEW TOYS :heart:

I'm letting the changes be minimal in here to make use of the new Go 1.18 features. I snuck in the `any` type change just because its sooo nice and quite the minor change.
