### PR TITLE
Added canary build and `--version`

### DIFF
--- a/.wharf-ci.yml
+++ b/.wharf-ci.yml
@@ -1,0 +1,10 @@
+build:
+  wharf-cmd:
+    docker:
+      file: Dockerfile
+      tag: canary
+      args:
+        - BUILD_VERSION=${GIT_BRANCH}
+        - BUILD_GIT_COMMIT=${GIT_COMMIT}
+        - BUILD_REF=${BUILD_REF}
+        - REG=${REG_URL}/hub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added HTTP client in `pkg/workerapi/workerclient` to interface with
   worker HTTP server. (#51)
 
+- Added `--version`, `-v` flag to show the version of wharf-cmd. (#76)
+
 - Added dependencies:
 
   - `github.com/alta/protopatch` v0.5.0 (#51)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG REG=docker.io
-FROM ${REG}/library/golang:1.17 AS build
+FROM ${REG}/library/golang:1.18 AS build
 WORKDIR /src
-RUN go install github.com/swaggo/swag/cmd/swag@v1.7.1
+RUN go install github.com/swaggo/swag/cmd/swag@v1.8.0
 COPY go.mod go.sum ./
 RUN go mod download
 
@@ -16,7 +16,7 @@ RUN chmod +x scripts/update-version.sh  \
     && CGO_ENABLED=0 go build -o main
 
 ARG REG=docker.io
-FROM ${REG}/library/alpine:3.14 AS final
+FROM ${REG}/library/alpine:3.15 AS final
 RUN apk add --no-cache ca-certificates tzdata
 WORKDIR /app
 COPY --from=build /src/main ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,40 @@
-FROM golang:1.18 AS build
+ARG REG=docker.io
+FROM ${REG}/library/golang:1.17 AS build
 WORKDIR /src
-ENV GO111MODULE=on
-COPY . /src
-RUN CGO_ENABLED=0 go build -o main && go test ./... -v
+RUN go install github.com/swaggo/swag/cmd/swag@v1.7.1
+COPY go.mod go.sum ./
+RUN go mod download
 
-FROM ubuntu:20.04 AS final
+COPY . .
+ARG BUILD_VERSION="local docker"
+ARG BUILD_GIT_COMMIT="HEAD"
+ARG BUILD_REF="0"
+ARG BUILD_DATE=""
+RUN chmod +x scripts/update-version.sh  \
+    && scripts/update-version.sh assets/version.yaml \
+    && make swag check \
+    && CGO_ENABLED=0 go build -o main
+
+ARG REG=docker.io
+FROM ${REG}/library/alpine:3.14 AS final
+RUN apk add --no-cache ca-certificates tzdata
 WORKDIR /app
-COPY --from=build /src/main /app/
-ADD conf/config .kube/config
-ADD conf/root.crt conf/int.crt /usr/local/share/ca-certificates/
-RUN apt update && apt install -y ca-certificates && update-ca-certificates
+COPY --from=build /src/main ./
 ENTRYPOINT ["/app/main"]
+
+ARG BUILD_VERSION
+ARG BUILD_GIT_COMMIT
+ARG BUILD_REF
+ARG BUILD_DATE
+# The added labels are based on this: https://github.com/projectatomic/ContainerApplicationGenericLabels
+LABEL name="iver-wharf/wharf-cmd" \
+    url="https://github.com/iver-wharf/wharf-cmd" \
+    release=${BUILD_REF} \
+    build-date=${BUILD_DATE} \
+    vendor="Iver" \
+    version=${BUILD_VERSION} \
+    vcs-type="git" \
+    vcs-url="https://github.com/iver-wharf/wharf-cmd" \
+    vcs-ref=${BUILD_GIT_COMMIT} \
+    changelog-url="https://github.com/iver-wharf/wharf-cmd/blob/${BUILD_VERSION}/CHANGELOG.md" \
+    authoritative-source-url="quay.io"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install tidy deps \
+.PHONY: install tidy deps check \
 	swag swag-force proto \
 	lint lint-md lint-go \
 	lint-fix lint-fix-md lint-fix-go
@@ -25,6 +25,9 @@ deps:
 	go install github.com/alta/protopatch/cmd/protoc-gen-go-patch@v0.5.0
 	go install github.com/swaggo/swag/cmd/swag@v1.8.0
 	npm install
+
+check:
+	go test ./...
 
 proto:
 	protoc -I . \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: install tidy deps check \
-	swag swag-force proto \
+	docker docker-run swag swag-force proto \
 	lint lint-md lint-go \
 	lint-fix lint-fix-md lint-fix-go
 
@@ -38,6 +38,24 @@ proto:
 		./api/workerapi/v1/worker.proto
 # Generated files have some non-standard formatting, so let's format it.
 	goimports -w ./api/workerapi/v1/.
+
+docker:
+	docker build . \
+		--pull \
+		-t "quay.io/iver-wharf/wharf-cmd:latest" \
+		-t "quay.io/iver-wharf/wharf-cmd:$(version)" \
+		--build-arg BUILD_VERSION="$(version)" \
+		--build-arg BUILD_GIT_COMMIT="$(commit)" \
+		--build-arg BUILD_DATE="$(shell date --iso-8601=seconds)"
+	@echo ""
+	@echo "Push the image by running:"
+	@echo "docker push quay.io/iver-wharf/wharf-cmd:latest"
+ifneq "$(version)" "latest"
+	@echo "docker push quay.io/iver-wharf/wharf-cmd:$(version)"
+endif
+
+docker-run:
+	docker run --rm -it quay.io/iver-wharf/wharf-api:$(version)
 
 swag-force:
 	swag init \

--- a/assets/version.yaml
+++ b/assets/version.yaml
@@ -1,0 +1,5 @@
+# This file is updated by scripts/update-version.sh in our CI/CD pipeline
+version: local dev
+buildGitCommit: HEAD
+buildDate: null
+buildRef: 0

--- a/main.go
+++ b/main.go
@@ -1,7 +1,28 @@
 package main
 
-import "github.com/iver-wharf/wharf-cmd/cmd"
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/iver-wharf/wharf-cmd/cmd"
+	"github.com/iver-wharf/wharf-core/pkg/app"
+)
+
+//go:embed assets/version.yaml
+var versionFile []byte
+
+func getVersion() (app.Version, error) {
+	var version app.Version
+	if err := app.UnmarshalVersionYAML(versionFile, &version); err != nil {
+		return app.Version{}, fmt.Errorf("load version file: %w", err)
+	}
+	return version, nil
+}
 
 func main() {
-	cmd.Execute()
+	version, err := getVersion()
+	if err != nil {
+		fmt.Println("Failed to load version:", err)
+	}
+	cmd.Execute(version)
 }

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+VERSION_FILE="${1:?'Version file must be provided'}"
+
+# Required environment variables
+: ${BUILD_VERSION:?'Version must be supplied'}
+: ${BUILD_GIT_COMMIT:?'CI Git commit must be supplied'}
+: ${BUILD_REF:?'CI build reference ID must be supplied'}
+
+# Optional environment variables
+: ${BUILD_DATE:="$(date '+%FT%T%:z')"}
+
+cat <<EOF > "$VERSION_FILE"
+version: ${BUILD_VERSION}
+buildGitCommit: ${BUILD_GIT_COMMIT}
+buildDate: ${BUILD_DATE}
+buildRef: ${BUILD_REF}
+EOF
+


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Updated Dockerfile, based on wharf-api's Dockerfile
- Added `docker` target to Makefile
- Added `scripts/update-version.sh`
- Added `assets/version.yaml`
- Added `--version`, `-v` flag to root command to show version

## Motivation

Only planning to use this to create canary builds of wharf-cmd so that we can at least test it out.

The additional version addition slipped in because wharf-api used it, and it was such an easy change to do, and somewhat related to this PR anyway.

Closes #20
