### PR TITLE
Added safeexec.LookPath in pkg/gitstat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   ```
 
 - Added Git integration by executing `git` locally to obtain current branch,
-  commit SHA, tags, etc. (#67)
+  commit SHA, tags, etc. (#67, #78)
 
 - Fixed `wharf run` not reading a pod's logs when it fails immediately on start.
   (#50)
@@ -128,6 +128,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added dependencies:
 
   - `github.com/alta/protopatch` v0.5.0 (#51)
+  - `github.com/cli/safeexec` v1.0.0 (#78)
   - `github.com/gin-contrib/cors` v1.3.1 (#51)
   - `github.com/gin-gonic/gin` v1.7.1 (#46)
   - `github.com/golang/protobuf` v1.5.2 (#51)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/alta/protopatch v0.5.0
+	github.com/cli/safeexec v1.0.0
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.7.7
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
+github.com/cli/safeexec v1.0.0 h1:0VngyaIyqACHdcMNWfo6+KdUYnqEr2Sg+bSP1pdF+dI=
+github.com/cli/safeexec v1.0.0/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/pkg/gitstat/gitstat.go
+++ b/pkg/gitstat/gitstat.go
@@ -13,6 +13,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/cli/safeexec"
 )
 
 var (
@@ -239,7 +241,11 @@ func execGitCmdLines(dir string, args ...string) ([]string, error) {
 }
 
 func execGitCmd(dir string, args ...string) (string, error) {
-	cmd := exec.Command("git", append([]string{"-C", dir, "--no-pager"}, args...)...)
+	gitBin, err := safeexec.LookPath("git")
+	if err != nil {
+		return "", wrapGitExecError(err, args)
+	}
+	cmd := exec.Command(gitBin, append([]string{"-C", dir, "--no-pager"}, args...)...)
 	outBytes, err := cmd.CombinedOutput()
 	outBytes = bytes.TrimSpace(outBytes)
 	if err != nil {


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added `github.com/cli/safeexec.LookPath` inside `pkg/gitstat`

## Motivation

Patches a security vulnerability in Go's built-in [`exec.LookPath()`](https://golang.org/pkg/os/exec/#LookPath) on Windows, where it will first look for `.\git.exe` or `.\git.bat` before trying to find the executable in the `PATH` environment variable.

Repo: <https://github.com/cli/safeexec>
