### PR TITLE
Renamed variable `any` -> `anyLine`

### DIFF
--- a/pkg/resultstore/loglinereader.go
+++ b/pkg/resultstore/loglinereader.go
@@ -52,16 +52,16 @@ func (r *logLineReadCloser) Close() error {
 }
 
 func (r *logLineReadCloser) ReadLastLogLine() (LogLine, error) {
-	var anyLine bool
+	noLineFound := true
 	var lastLine string
 	for r.scan() {
-		anyLine = true
+		noLineFound = false
 		lastLine = r.scanner.Text()
 	}
 	if err := r.scanner.Err(); err != nil {
 		return LogLine{}, err
 	}
-	if !anyLine {
+	if noLineFound {
 		return LogLine{}, io.EOF
 	}
 	return r.parseLogLine(lastLine), nil

--- a/pkg/resultstore/loglinereader.go
+++ b/pkg/resultstore/loglinereader.go
@@ -52,16 +52,16 @@ func (r *logLineReadCloser) Close() error {
 }
 
 func (r *logLineReadCloser) ReadLastLogLine() (LogLine, error) {
-	var any bool
+	var anyLine bool
 	var lastLine string
 	for r.scan() {
-		any = true
+		anyLine = true
 		lastLine = r.scanner.Text()
 	}
 	if err := r.scanner.Err(); err != nil {
 		return LogLine{}, err
 	}
-	if !any {
+	if !anyLine {
 		return LogLine{}, io.EOF
 	}
 	return r.parseLogLine(lastLine), nil


### PR DESCRIPTION
## Summary

- Renamed `any` -> `anyLine`

## Motivation

Collided with the new built in `any` type from Go 1.18. Was still valid code, but the linter warned about it.
