### PR TITLE
Changed to 0775 permission on resultstore MkdirAll

### DIFF
--- a/pkg/resultstore/fs.go
+++ b/pkg/resultstore/fs.go
@@ -56,7 +56,7 @@ func (fs osFS) openFileMkdirAll(name string, flags int, perm fs.FileMode) (io.Wr
 	file, err := os.OpenFile(path, flags, perm)
 	if os.IsNotExist(err) {
 		dir := filepath.Dir(path)
-		if err := os.MkdirAll(dir, perm); err != nil {
+		if err := os.MkdirAll(dir, 0775); err != nil {
 			return nil, err
 		}
 		return os.OpenFile(path, flags, perm)


### PR DESCRIPTION
## Summary

- Changed from borrowing the file's permission in MkdirAll to hardcoded 0755

## Motivation

Got permission error. Borrowing the file's permission of 0644 wasen't good enough.
