### PR TITLE
Renamed binary from wharf-cmd to wharf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added provisioner commands: (#46, #59)
 
-  - `wharf-cmd provisioner serve` that launches an HTTP REST api server with
+  - `wharf provisioner serve` that launches an HTTP REST api server with
     endpoints:
 
     - `GET /api` to check health.
@@ -30,21 +30,21 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
     - `DELETE /api/worker/:workerId` deletes a worker, as long as it has
       certain labels.
 
-  - `wharf-cmd provisioner create` that creates a new worker.
+  - `wharf provisioner create` that creates a new worker.
 
-  - `wharf-cmd provisioner list` that lists all running workers with certain
+  - `wharf provisioner list` that lists all running workers with certain
     labels.
 
-  - `wharf-cmd provisioner delete` with flag `--id` to specify the worker that
+  - `wharf provisioner delete` with flag `--id` to specify the worker that
     should be deleted, as long as it has certain labels as well.
 
 - Added watchdog commands: (#62)
 
-  - `wharf-cmd watchdog serve` checks stray builds from the wharf-api and
+  - `wharf watchdog serve` checks stray builds from the wharf-api and
     wharf-cmd-workers from the wharf-cmd-provisioner and kills them in an effort
     to clean up forgotten builds/workers.
 
-- Added aggregator command `wharf-cmd aggregator serve` that looks for
+- Added aggregator command `wharf aggregator serve` that looks for
   wharf-cmd-worker pods and pipes build results over to the wharf-api. (#77)
 
 - Added new implementation for `wharf run`. (#33, #45, #66)
@@ -54,7 +54,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   line & column of each parse error. (#48, #58)
 
 - Added support for a new file type: `.wharf-vars.yml`. It is used to define
-  built-in variables, and wharf-cmd looks for it in multiple files in the
+  built-in variables, and wharf looks for it in multiple files in the
   following order, where former files take precedence over latter files on a
   per-variable basis: (#73)
 
@@ -92,10 +92,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   your shell for more info: (#64)
 
   ```bash
-  wharf-cmd completion bash --help
-  wharf-cmd completion fish --help
-  wharf-cmd completion powershell --help
-  wharf-cmd completion zsh --help
+  wharf completion bash --help
+  wharf completion fish --help
+  wharf completion powershell --help
+  wharf completion zsh --help
   ```
 
 - Added Git integration by executing `git` locally to obtain current branch,
@@ -175,6 +175,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
   - File `pkg/core/utils/variablesreplacer.go` to its own package in `pkg/varsub`
   - Package `pkg/core/wharfyml` to `pkg/wharfyml`
+  - Command `main.go` to `cmd/wharf/main.go`
 
 - Removed packages: (#44)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,7 +171,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Changed to trim away everything before the last CR (carriage return)
   character in a log line from a Kubernetes pod. (#49)
 
-- Changed location of packages and code files: (#44)
+- Changed location of packages and code files: (#44, #87)
 
   - File `pkg/core/utils/variablesreplacer.go` to its own package in `pkg/varsub`
   - Package `pkg/core/wharfyml` to `pkg/wharfyml`

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ wharf: swag
 endif
 
 install: swag
-	go install
+	go install ./cmd/wharf
 
 tidy:
 	go mod tidy

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 A command-line interface to run tasks specified in a `.wharf-ci.yml` file.
 
+## Installation
+
+Requires Go 1.18 (or later)
+
+```sh
+go install github.com/iver-wharf/wharf-cmd/cmd/wharf@latest
+```
+
 ## Commands
 
 ### Run

--- a/cmd/wharf/aggregator.go
+++ b/cmd/wharf/aggregator.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"github.com/spf13/cobra"

--- a/cmd/wharf/aggregator_serve.go
+++ b/cmd/wharf/aggregator_serve.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"context"

--- a/cmd/wharf/logger.go
+++ b/cmd/wharf/logger.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import "github.com/iver-wharf/wharf-core/pkg/logger"
 

--- a/cmd/wharf/main.go
+++ b/cmd/wharf/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/iver-wharf/wharf-cmd"
+	wharfcmd "github.com/iver-wharf/wharf-cmd"
 )
 
 func main() {

--- a/cmd/wharf/main.go
+++ b/cmd/wharf/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/iver-wharf/wharf-cmd"
+)
+
+func main() {
+	version, err := wharfcmd.GetVersion()
+	if err != nil {
+		fmt.Println("Failed to load version:", err)
+	}
+	execute(version)
+}

--- a/cmd/wharf/provisioner.go
+++ b/cmd/wharf/provisioner.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"github.com/spf13/cobra"
@@ -19,9 +19,9 @@ var provisionerCmd = &cobra.Command{
 	Long: `Provisions workers, which are Kubernetes pods running wharf-cmd
 that clones the repository and run the .wharf-ci.yml file inside the repo.
 
-The "wharf-cmd provisioner" act as a fire-and-forget, where the entire build
+The "wharf provisioner" act as a fire-and-forget, where the entire build
 orchestration is handled inside the Kubernetes cluster, in comparison to the
-"wharf-cmd run" command that uses your local machine to orchestrate the build.
+"wharf run" command that uses your local machine to orchestrate the build.
 `,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		restConfig, ns, err := loadKubeconfig(provisionerFlags.k8sOverrides)

--- a/cmd/wharf/provisioner_create.go
+++ b/cmd/wharf/provisioner_create.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"context"
@@ -11,7 +11,7 @@ var provisionerCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Starts a build via a new worker inside a Kubernetes pod",
 	Long: `Creates a new Kubernetes pod that clones a Git repo and
-a container running "wharf-cmd run" to perform the build.
+a container running "wharf run" to perform the build.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		p, err := provisioner.NewK8sProvisioner(provisionerFlags.namespace, provisionerFlags.restConfig)

--- a/cmd/wharf/provisioner_delete.go
+++ b/cmd/wharf/provisioner_delete.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"context"
@@ -11,7 +11,7 @@ var deleteWorkerID string
 var provisionerDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Terminates a worker in Kubernetes",
-	Long: `Terminates a wharf-cmd worker pod in Kubernetes, effectively
+	Long: `Terminates a wharf worker pod in Kubernetes, effectively
 cancelling the build.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		p, err := provisioner.NewK8sProvisioner(provisionerFlags.namespace, provisionerFlags.restConfig)

--- a/cmd/wharf/provisioner_list.go
+++ b/cmd/wharf/provisioner_list.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 var provisionerListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Lists current workers inside Kubernetes",
-	Long: `Lists wharf-cmd worker pods inside Kubernetes
+	Long: `Lists wharf worker pods inside Kubernetes
 that are either scheduling, running, or completed.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		p, err := provisioner.NewK8sProvisioner(provisionerFlags.namespace, provisionerFlags.restConfig)

--- a/cmd/wharf/provisioner_serve.go
+++ b/cmd/wharf/provisioner_serve.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"github.com/iver-wharf/wharf-cmd/pkg/provisionerapi"
@@ -10,10 +10,10 @@ var provisionerServeCmd = &cobra.Command{
 	Short: "Starts serving HTTP REST API",
 	Long: `Starts serving a HTTP REST API that the wharf-api uses to
 provision new builds inside Kubernetes. The endpoints available are
-equivalent to the "wharf-cmd provisioner" subcommands.
+equivalent to the "wharf provisioner" subcommands.
 
 You can see an offline Swagger documentation of the API by visiting
-the following URL path on a running wharf-cmd provisioner server:
+the following URL path on a running wharf provisioner server:
 
 	/api/swagger/index.html
 `,

--- a/cmd/wharf/root.go
+++ b/cmd/wharf/root.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"fmt"
@@ -49,8 +49,7 @@ func loadKubeconfig(overrides clientcmd.ConfigOverrides) (*rest.Config, string, 
 	return restConf, ns, nil
 }
 
-// Execute is the entrypoint for wharf-cmd's CLI.
-func Execute(version app.Version) {
+func execute(version app.Version) {
 	rootCmd.Version = versionString(version)
 	if err := rootCmd.Execute(); err != nil {
 		initLoggingIfNeeded()

--- a/cmd/wharf/root.go
+++ b/cmd/wharf/root.go
@@ -21,7 +21,7 @@ var loglevel string
 var rootCmd = &cobra.Command{
 	SilenceErrors: true,
 	SilenceUsage:  true,
-	Use:           "wharf-cmd",
+	Use:           "wharf",
 	Short:         "Ci application to generate .wharf-ci.yml files and execute them against a kubernetes cluster",
 	Long:          ``,
 }

--- a/cmd/wharf/run.go
+++ b/cmd/wharf/run.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"context"
@@ -33,7 +33,7 @@ var runCmd = &cobra.Command{
 	Long: `Runs a new build in a Kubernetes cluster using pods
 based on a .wharf-ci.yml file.
 
-If no stage is specified via --stage then wharf-cmd will run all stages
+If no stage is specified via --stage then wharf will run all stages
 in sequence, based on their order of declaration in the .wharf-ci.yml file.
 
 All steps in each stage will be run in parallel for each stage.

--- a/cmd/wharf/watchdog.go
+++ b/cmd/wharf/watchdog.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"github.com/spf13/cobra"

--- a/cmd/wharf/watchdog_serve.go
+++ b/cmd/wharf/watchdog_serve.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"github.com/iver-wharf/wharf-cmd/pkg/watchdog"

--- a/docs/build-result-logs.md
+++ b/docs/build-result-logs.md
@@ -4,10 +4,10 @@ Logs are retrieved by wharf-cmd-worker and then saved to disk so that other
 components, such as wharf-cmd-aggregator, can download them safely when they
 feel ready.
 
-If you run wharf-cmd locally then you can access the build logs safely in your
+If you run `wharf` locally then you can access the build logs safely in your
 editor of choice after the build is completed. The location of these logs depend
 on your OS (Windows vs GNU/Linux), but is best sought after in wharf-cmd's help
-text by running `wharf-cmd run --help`.
+text by running `wharf run --help`.
 
 ## Streaming
 

--- a/pkg/provisioner/k8sprovisioner.go
+++ b/pkg/provisioner/k8sprovisioner.go
@@ -150,7 +150,7 @@ func createPodMeta() v1.Pod {
 						`
 make deps-go swag install && \
 cd test/wharf-ci-simple && \
-wharf-cmd run --serve --stage test --loglevel debug`,
+wharf run --serve --stage test --loglevel debug`,
 					},
 					WorkingDir:   repoVolumeMountPath,
 					VolumeMounts: volumeMounts,

--- a/version.go
+++ b/version.go
@@ -1,28 +1,20 @@
-package main
+package wharfcmd
 
 import (
 	_ "embed"
 	"fmt"
 
-	"github.com/iver-wharf/wharf-cmd/cmd"
 	"github.com/iver-wharf/wharf-core/pkg/app"
 )
 
 //go:embed assets/version.yaml
 var versionFile []byte
 
-func getVersion() (app.Version, error) {
+// GetVersion returns this app's version.
+func GetVersion() (app.Version, error) {
 	var version app.Version
 	if err := app.UnmarshalVersionYAML(versionFile, &version); err != nil {
 		return app.Version{}, fmt.Errorf("load version file: %w", err)
 	}
 	return version, nil
-}
-
-func main() {
-	version, err := getVersion()
-	if err != nil {
-		fmt.Println("Failed to load version:", err)
-	}
-	cmd.Execute(version)
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Moved `cmd/*.go` to `cmd/wharf/*.go`
- Moved `main.go` to `cmd/wharf/main.go`

## Motivation

Currently the CLI gets the automatic name `wharf-cmd` by Go when doing `go build` or `go install`.

This changes it so:

- `go install github.com/iver-wharf/wharf-cmd@latest` doesn't work
- `go install github.com/iver-wharf/wharf-cmd/cmd/wharf@latest` produces `wharf` binary
- `make` and `make install` produces `wharf` binary

Closes #35
