### PR TITLE
Added --stage & --environment completions

### DIFF
--- a/pkg/wharfyml/definition.go
+++ b/pkg/wharfyml/definition.go
@@ -69,8 +69,10 @@ func visitDefNode(node *yaml.Node, args Args) (def Definition, errSlice Errors) 
 	def.Stages = stages
 	errSlice.add(errs...)
 	errSlice.add(validateDefEnvironmentUsage(def)...)
-	// filtering intentionally performed after validation
-	def.Stages = filterStagesOnEnv(def.Stages, args.Env)
+	if !args.SkipStageFiltering {
+		// filtering intentionally performed after validation
+		def.Stages = filterStagesOnEnv(def.Stages, args.Env)
+	}
 	return
 }
 

--- a/pkg/wharfyml/parse.go
+++ b/pkg/wharfyml/parse.go
@@ -15,8 +15,9 @@ import (
 // Args specify arguments used when parsing the .wharf-ci.yml file, such as what
 // environment to use for variable substitution.
 type Args struct {
-	Env       string
-	VarSource varsub.Source
+	Env                string
+	VarSource          varsub.Source
+	SkipStageFiltering bool
 }
 
 // ParseFile will parse the file at the given path.


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added completions for `--stage` and `--environment` flags based on values from a parsed `.wharf-ci.yml`.

## Motivation

Quality of life feature.
