### PR TITLE
Added varsub listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added new implementation for `wharf run`. (#33, #45, #66, #84)
 
+- Added "vars" command `wharf vars` that prints out all the variables that
+  would be used in a `wharf run` invocation. (#93)
+
 - Added support for `.gitignore` ignored files and directories when transferring
   repo in `wharf run`. Can be disabled via new `--no-gitignore` flag. (#85)
 

--- a/cmd/wharf/run.go
+++ b/cmd/wharf/run.go
@@ -59,11 +59,12 @@ https://iver-wharf.github.io/#/usage-wharfyml/`,
 		if err != nil {
 			return err
 		}
-		def, varSource, err := parseBuildDefinition(currentDir)
+		def, err := parseBuildDefinition(currentDir, wharfyml.Args{
+			Env: runFlags.env,
+		})
 		if err != nil {
 			return err
 		}
-		log.Debug().Message("Successfully parsed .wharf-ci.yml")
 
 		// TODO: Change to build ID-based path, e.g /tmp/iver-wharf/wharf-cmd/builds/123/...
 		//
@@ -87,7 +88,7 @@ https://iver-wharf.github.io/#/usage-wharfyml/`,
 				ResultStore:   store,
 				SkipGitIgnore: runFlags.noGitIgnore,
 				TarStore:      tarStore,
-				VarSource:     varSource,
+				VarSource:     def.VarSource,
 			})
 		if err != nil {
 			return err
@@ -153,13 +154,16 @@ func parseCurrentDir(dirArg string) (string, error) {
 	return abs, nil
 }
 
-func parseBuildDefinition(currentDir string) (wharfyml.Definition, varsub.Source, error) {
+func parseBuildDefinition(currentDir string, ymlArgs wharfyml.Args) (wharfyml.Definition, error) {
 	var varSources varsub.SourceSlice
+	if ymlArgs.VarSource != nil {
+		varSources = append(varSources, ymlArgs.VarSource)
+	}
 
 	varFileSource, errs := wharfyml.ParseVarFiles(currentDir)
 	if len(errs) > 0 {
 		logParseErrors(errs, currentDir)
-		return wharfyml.Definition{}, nil, errors.New("failed to parse variable files")
+		return wharfyml.Definition{}, errors.New("failed to parse variable files")
 	}
 	if varFileSource != nil {
 		varSources = append(varSources, varFileSource)
@@ -175,20 +179,17 @@ func parseBuildDefinition(currentDir string) (wharfyml.Definition, varsub.Source
 		varSources = append(varSources, gitStats)
 	}
 
+	ymlArgs.VarSource = varSources
+
 	ymlPath := filepath.Join(currentDir, ".wharf-ci.yml")
 	log.Debug().WithString("path", ymlPath).Message("Parsing .wharf-ci.yml file.")
-	def, errs := wharfyml.ParseFile(ymlPath, wharfyml.Args{
-		Env:       runFlags.env,
-		VarSource: varSources,
-	})
+	def, errs := wharfyml.ParseFile(ymlPath, ymlArgs)
 	if len(errs) > 0 {
 		logParseErrors(errs, currentDir)
-		return wharfyml.Definition{}, nil, errors.New("failed to parse .wharf-ci.yml")
+		return wharfyml.Definition{}, errors.New("failed to parse .wharf-ci.yml")
 	}
-	if def.Env != nil {
-		varSources = append(varSources, varsub.SourceMap(def.Env.Vars))
-	}
-	return def, varSources, nil
+	log.Debug().Message("Successfully parsed .wharf-ci.yml")
+	return def, nil
 }
 
 func startWorkerServerWithCancel(ctx context.Context, store resultstore.Store) (context.Context, workerserver.Server) {

--- a/cmd/wharf/vars.go
+++ b/cmd/wharf/vars.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/iver-wharf/wharf-cmd/pkg/varsub"
+	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml"
+	"github.com/spf13/cobra"
+	"gopkg.in/typ.v3/pkg/slices"
+)
+
+var varsFlags = struct {
+	env string
+}{}
+
+var varsCmd = &cobra.Command{
+	Use:   "vars [path]",
+	Short: "Print all variables that would be used for a .wharf-ci.yml file",
+	Long:  ``,
+	Args:  cobra.MaximumNArgs(1),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"yml"}, cobra.ShellCompDirectiveFilterFileExt
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		currentDir, err := parseCurrentDir(slices.SafeGet(args, 0))
+		if err != nil {
+			return err
+		}
+
+		def, err := parseBuildDefinition(currentDir, wharfyml.Args{
+			Env: varsFlags.env,
+		})
+		if err != nil {
+			return err
+		}
+
+		vars := def.VarSource.ListVars()
+
+		if len(vars) == 0 {
+			if len(def.Envs) > 0 {
+				var env wharfyml.Env
+				for _, e := range def.Envs {
+					env = e
+					break
+				}
+				log.Info().Messagef(`No variables found.
+
+Try specifying the --environment flag to include
+environment variables, such as:
+
+  %s vars --environment %q`, os.Args[0], env.Name)
+				return nil
+			}
+
+			log.Info().Messagef("No variables found.")
+			return nil
+		}
+
+		groups := slices.GroupBy(vars, func(v varsub.Var) string {
+			return v.Source
+		})
+		slices.Reverse(groups)
+
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "Found %d variables from %d different sources:\n", len(vars), len(groups))
+
+		for _, g := range groups {
+			slices.SortFunc(g.Values, func(a, b varsub.Var) bool {
+				return a.Key < b.Key
+			})
+
+			var longestKeyLength int
+			for _, v := range g.Values {
+				if len(v.Key) > longestKeyLength {
+					longestKeyLength = len(v.Key)
+				}
+			}
+
+			if g.Key == "" {
+				sb.WriteString("\n(undefined source):\n")
+			} else {
+				fmt.Fprintf(&sb, "\n%s:\n", g.Key)
+			}
+
+			format := fmt.Sprintf("  %%%ds %%v\n", -longestKeyLength-1)
+			for _, v := range g.Values {
+				fmt.Fprintf(&sb, format, v.Key, v.Value)
+			}
+		}
+
+		log.Info().Message(sb.String())
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(varsCmd)
+
+	varsCmd.Flags().StringVarP(&varsFlags.env, "environment", "e", "", "Environment selection")
+}

--- a/cmd/wharf/vars.go
+++ b/cmd/wharf/vars.go
@@ -18,8 +18,14 @@ var varsFlags = struct {
 var varsCmd = &cobra.Command{
 	Use:   "vars [path]",
 	Short: "Print all variables that would be used for a .wharf-ci.yml file",
-	Long:  ``,
-	Args:  cobra.MaximumNArgs(1),
+	Long: `Parses a .wharf-ci.yml and all .wharf-vars.yml files as if it was
+running "wharf run", but prints out all the variables that would be used
+instead of performing the build.
+
+The variables sources are printed in the order of priority, where the latter
+sources override the former sources, if a variable would have the same name
+in multiple sources.`,
+	Args: cobra.MaximumNArgs(1),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"yml"}, cobra.ShellCompDirectiveFilterFileExt
 	},

--- a/internal/gitutil/stats.go
+++ b/internal/gitutil/stats.go
@@ -94,6 +94,8 @@ var statsFields = []string{
 	"REPO_GROUP",
 }
 
+// ListVars will return a slice of all variables that this varsub Source
+// provides.
 func (s Stats) ListVars() []varsub.Var {
 	var vars []varsub.Var
 	for _, key := range statsFields {

--- a/pkg/varsub/copier_test.go
+++ b/pkg/varsub/copier_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 var testSource = SourceMap{
-	"var1": "value1",
-	"var2": "value2",
+	"var1": Val{Value: "value1"},
+	"var2": Val{Value: "value2"},
 }
 
 func TestCopier(t *testing.T) {

--- a/pkg/varsub/source.go
+++ b/pkg/varsub/source.go
@@ -1,10 +1,28 @@
 package varsub
 
+import "fmt"
+
 // Source is a variable substitution source.
 type Source interface {
 	// Lookup tries to look up a value based on name and returns that value as
 	// well as true on success, or false if the variable was not found.
-	Lookup(name string) (any, bool)
+	Lookup(name string) (Var, bool)
+
+	ListVars() []Var
+}
+
+type Var struct {
+	Key    string
+	Value  any
+	Source string
+}
+
+func (v Var) String() string {
+	return stringify(v.Value)
+}
+
+func (v Var) GoString() string {
+	return fmt.Sprintf("{%q:%[2]T(%#[2]v)}", v.Key, v.Value)
 }
 
 // SourceSlice is a slice of variable substution sources that act as a source
@@ -13,23 +31,62 @@ type SourceSlice []Source
 
 // Lookup tries to look up a value based on name and returns that value as
 // well as true on success, or false if the variable was not found.
-func (ss SourceSlice) Lookup(name string) (any, bool) {
-	for _, s := range ss {
-		val, ok := s.Lookup(name)
+func (s SourceSlice) Lookup(name string) (Var, bool) {
+	for _, inner := range s {
+		val, ok := inner.Lookup(name)
 		if ok {
 			return val, true
 		}
 	}
-	return nil, false
+	return Var{}, false
+}
+
+func (s SourceSlice) ListVars() []Var {
+	var vars []Var
+	for _, inner := range s {
+		vars = append(vars, inner.ListVars()...)
+	}
+	return vars
+}
+
+// ensure it conforms to interface
+var _ Source = SourceSlice{}
+
+type Val struct {
+	Value  any
+	Source string
+}
+
+func (v Val) String() string {
+	return stringify(v.Value)
 }
 
 // SourceMap is a variable substitution source based on a map where it uses the
 // underlying map as the variable source.
-type SourceMap map[string]any
+type SourceMap map[string]Val
 
 // Lookup tries to look up a value based on name and returns that value as
 // well as true on success, or false if the variable was not found.
-func (s SourceMap) Lookup(name string) (any, bool) {
-	val, ok := s[name]
-	return val, ok
+func (s SourceMap) Lookup(name string) (Var, bool) {
+	v, ok := s[name]
+	return Var{
+		Key:    name,
+		Value:  v.Value,
+		Source: v.Source,
+	}, ok
+}
+
+// ensure it conforms to interface
+var _ Source = SourceMap{}
+
+func (s SourceMap) ListVars() []Var {
+	var vars []Var
+	for k, v := range s {
+		vars = append(vars, Var{
+			Key:    k,
+			Value:  v.Value,
+			Source: v.Source,
+		})
+	}
+	return vars
 }

--- a/pkg/varsub/source.go
+++ b/pkg/varsub/source.go
@@ -8,19 +8,25 @@ type Source interface {
 	// well as true on success, or false if the variable was not found.
 	Lookup(name string) (Var, bool)
 
+	// ListVars will return a slice of all variables that this varsub Source
+	// provides.
 	ListVars() []Var
 }
 
+// Var is a single varsub variable, with it's Key (name), Value, and optionally
+// also a Source that declares where this variable comes from.
 type Var struct {
 	Key    string
 	Value  any
 	Source string
 }
 
+// String implements the fmt.Stringer interface.
 func (v Var) String() string {
 	return stringify(v.Value)
 }
 
+// GoString implements the fmt.GoStringer interface.
 func (v Var) GoString() string {
 	return fmt.Sprintf("{%q:%[2]T(%#[2]v)}", v.Key, v.Value)
 }
@@ -41,6 +47,8 @@ func (s SourceSlice) Lookup(name string) (Var, bool) {
 	return Var{}, false
 }
 
+// ListVars will return a slice of all variables that this varsub Source
+// provides.
 func (s SourceSlice) ListVars() []Var {
 	var vars []Var
 	for _, inner := range s {
@@ -52,11 +60,14 @@ func (s SourceSlice) ListVars() []Var {
 // ensure it conforms to interface
 var _ Source = SourceSlice{}
 
+// Val is a slimmed down varsub.Var, without the Key, as the SourceMap will
+// populate the Key field automatically based on the map keys.
 type Val struct {
 	Value  any
 	Source string
 }
 
+// String implements the fmt.Stringer interface.
 func (v Val) String() string {
 	return stringify(v.Value)
 }
@@ -79,6 +90,8 @@ func (s SourceMap) Lookup(name string) (Var, bool) {
 // ensure it conforms to interface
 var _ Source = SourceMap{}
 
+// ListVars will return a slice of all variables that this varsub Source
+// provides.
 func (s SourceMap) ListVars() []Var {
 	var vars []Var
 	for k, v := range s {

--- a/pkg/varsub/varsub.go
+++ b/pkg/varsub/varsub.go
@@ -50,7 +50,7 @@ func substituteRec(value string, source Source, usedParams []string) (any, error
 			if !ok {
 				continue
 			}
-			matchVal = v
+			matchVal = v.Value
 			if str, ok := matchVal.(string); ok && strings.Contains(str, "${") {
 				var err error
 				matchVal, err = substituteRec(str, source, append(usedParams, match.Name))

--- a/pkg/varsub/varsub_test.go
+++ b/pkg/varsub/varsub_test.go
@@ -98,7 +98,7 @@ func TestMatches(t *testing.T) {
 
 func TestSubstitute(t *testing.T) {
 	source := SourceMap{
-		"lorem": "ipsum",
+		"lorem": Val{Value: "ipsum"},
 	}
 	tests := []struct {
 		name  string
@@ -180,49 +180,49 @@ func TestSubstitute_nonStrings(t *testing.T) {
 	}{
 		{
 			name:   "full/bool",
-			source: SourceMap{"lorem": true},
+			source: SourceMap{"lorem": Val{Value: true}},
 			value:  "${lorem}",
 			want:   true,
 		},
 		{
 			name:   "full/int",
-			source: SourceMap{"lorem": 123},
+			source: SourceMap{"lorem": Val{Value: 123}},
 			value:  "${lorem}",
 			want:   123,
 		},
 		{
 			name:   "full/float",
-			source: SourceMap{"lorem": 123.0},
+			source: SourceMap{"lorem": Val{Value: 123.0}},
 			value:  "${lorem}",
 			want:   123.0,
 		},
 		{
 			name:   "full/nil",
-			source: SourceMap{"lorem": nil},
+			source: SourceMap{"lorem": Val{Value: nil}},
 			value:  "${lorem}",
 			want:   nil,
 		},
 		{
 			name:   "embed/bool",
-			source: SourceMap{"lorem": true},
+			source: SourceMap{"lorem": Val{Value: true}},
 			value:  "foo ${lorem} bar",
 			want:   "foo true bar",
 		},
 		{
 			name:   "embed/int",
-			source: SourceMap{"lorem": 123},
+			source: SourceMap{"lorem": Val{Value: 123}},
 			value:  "foo ${lorem} bar",
 			want:   "foo 123 bar",
 		},
 		{
 			name:   "embed/float",
-			source: SourceMap{"lorem": 123.0},
+			source: SourceMap{"lorem": Val{Value: 123.0}},
 			value:  "foo ${lorem} bar",
 			want:   "foo 123 bar",
 		},
 		{
 			name:   "embed/nil",
-			source: SourceMap{"lorem": nil},
+			source: SourceMap{"lorem": Val{Value: nil}},
 			value:  "foo ${lorem} bar",
 			want:   "foo  bar",
 		},
@@ -247,8 +247,8 @@ func TestSubstitute_recursive(t *testing.T) {
 		{
 			name: "string",
 			source: SourceMap{
-				"one": "11${two}11",
-				"two": 2222,
+				"one": Val{Value: "11${two}11"},
+				"two": Val{Value: 2222},
 			},
 			value: "00${one}00",
 			want:  "001122221100",
@@ -256,11 +256,11 @@ func TestSubstitute_recursive(t *testing.T) {
 		{
 			name: "typed",
 			source: SourceMap{
-				"one": "${two}",
-				"two": 2222,
+				"one": Val{Value: "${two}"},
+				"two": Val{Value: 222},
 			},
 			value: "${one}",
-			want:  2222,
+			want:  222,
 		},
 	}
 
@@ -275,7 +275,7 @@ func TestSubstitute_recursive(t *testing.T) {
 
 func TestSubstitute_errIfRecursiveLoop(t *testing.T) {
 	source := SourceMap{
-		"lorem": "ipsum: ${lorem}",
+		"lorem": Val{Value: "ipsum: ${lorem}"},
 	}
 	result, err := Substitute("root: ${lorem}", source)
 	assert.ErrorIsf(t, err, ErrRecursiveLoop, "unexpected result: %q", result)

--- a/pkg/wharfyml/builtins.go
+++ b/pkg/wharfyml/builtins.go
@@ -43,10 +43,14 @@ func ParseVarFiles(currentDir string) (varsub.Source, Errors) {
 	nodeVarSource := make(varsub.SourceMap)
 	for _, varFile := range varFiles {
 		items, errs := tryReadVarsFileNodes(varFile.Path)
+		prettyPath := varFile.PrettyPath(currentDir)
 		errSlice = append(errSlice,
-			wrapPathErrorSlice(errs, varFile.PrettyPath(currentDir))...)
+			wrapPathErrorSlice(errs, prettyPath)...)
 		for _, item := range items {
-			nodeVarSource[item.key.value] = item.value
+			nodeVarSource[item.key.value] = varsub.Val{
+				Value:  VarSubNode{item.value},
+				Source: prettyPath,
+			}
 		}
 	}
 	return nodeVarSource, errSlice

--- a/pkg/wharfyml/builtins_test.go
+++ b/pkg/wharfyml/builtins_test.go
@@ -3,24 +3,15 @@ package wharfyml
 import (
 	"testing"
 
+	"github.com/iver-wharf/wharf-cmd/pkg/varsub"
 	"github.com/stretchr/testify/assert"
 )
 
-type testVarSource struct{}
-
-func (testVarSource) Lookup(name string) (interface{}, bool) {
-	switch name {
-	case "REPO_GROUP":
-		return "iver-wharf", true
-	case "REPO_NAME":
-		return "wharf-cmd", true
-	case "REG_URL":
-		return "http://harbor.example.com", true
-	case "CHART_REPO":
-		return "http://charts.example.com", true
-	default:
-		return nil, false
-	}
+var testVarSource = varsub.SourceMap{
+	"REPO_GROUP": varsub.Val{Value: "iver-wharf"},
+	"REPO_NAME":  varsub.Val{Value: "wharf-cmd"},
+	"REG_URL":    varsub.Val{Value: "http://harbor.example.com"},
+	"CHART_REPO": varsub.Val{Value: "http://charts.example.com"},
 }
 
 func TestListParentDirsPossibleBuiltinVarsFiles(t *testing.T) {

--- a/pkg/wharfyml/environment.go
+++ b/pkg/wharfyml/environment.go
@@ -20,6 +20,8 @@ type Env struct {
 	Vars   map[string]VarSubNode
 }
 
+// VarSource returns a varsub.Source compliant value of the environment
+// variables.
 func (e Env) VarSource() varsub.Source {
 	source := make(varsub.SourceMap)
 	name := fmt.Sprintf(".wharf-ci.yml, environment %q", e.Name)

--- a/pkg/wharfyml/environment.go
+++ b/pkg/wharfyml/environment.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/iver-wharf/wharf-cmd/pkg/varsub"
 	"gopkg.in/yaml.v3"
 )
 
@@ -16,7 +17,19 @@ var (
 type Env struct {
 	Source Pos
 	Name   string
-	Vars   map[string]any
+	Vars   map[string]VarSubNode
+}
+
+func (e Env) VarSource() varsub.Source {
+	source := make(varsub.SourceMap)
+	name := fmt.Sprintf(".wharf-ci.yml, environment %q", e.Name)
+	for k, v := range e.Vars {
+		source[k] = varsub.Val{
+			Value:  v,
+			Source: name,
+		}
+	}
+	return source
 }
 
 // EnvRef is a reference to an environments definition. Used in stages.
@@ -41,39 +54,22 @@ func visitDocEnvironmentsNode(node *yaml.Node) (map[string]Env, Errors) {
 func visitEnvironmentNode(nameNode strNode, node *yaml.Node) (env Env, errSlice Errors) {
 	env = Env{
 		Name:   nameNode.value,
-		Vars:   make(map[string]any),
+		Vars:   make(map[string]VarSubNode),
 		Source: newPosNode(node),
 	}
 	nodes, errs := visitMapSlice(node)
 	errSlice.add(errs...)
 	for _, n := range nodes {
-		val, err := visitEnvironmentVariableNode(n.value)
-		if err != nil {
+		if err := verifyEnvironmentVariableNode(n.value); err != nil {
 			errSlice.add(wrapPathError(err, n.key.value))
 		}
-		env.Vars[n.key.value] = val
+		env.Vars[n.key.value] = VarSubNode{n.value}
 	}
 	return
 }
 
-func visitEnvironmentVariableNode(node *yaml.Node) (any, error) {
-	if err := verifyKind(node, "string, boolean, or number", yaml.ScalarNode); err != nil {
-		return nil, err
-	}
-	switch node.ShortTag() {
-	case shortTagBool:
-		return visitBool(node)
-	case shortTagInt:
-		return visitInt(node)
-	case shortTagFloat:
-		return visitFloat64(node)
-	case shortTagString:
-		return visitString(node)
-	default:
-		return nil, wrapPosErrorNode(fmt.Errorf(
-			"%w: expected string, boolean, or number, but found %s",
-			ErrInvalidFieldType, prettyNodeTypeName(node)), node)
-	}
+func verifyEnvironmentVariableNode(node *yaml.Node) error {
+	return verifyKind(node, "string, boolean, or number", yaml.ScalarNode)
 }
 
 func visitStageEnvironmentsNode(node *yaml.Node) (envs []EnvRef, errSlice Errors) {

--- a/pkg/wharfyml/environment_test.go
+++ b/pkg/wharfyml/environment_test.go
@@ -72,7 +72,9 @@ myEnv:
 		"myString": "foo bar",
 		"myBool":   true,
 	}
-	assert.Equal(t, want, env.Vars)
+	for k, wantValue := range want {
+		assertVarSubNode(t, wantValue, env.Vars[k], "env.Vars[%q]", k)
+	}
 }
 
 func TestVisitStageEnvironments_ErrIfNotArray(t *testing.T) {

--- a/pkg/wharfyml/steptype_test.go
+++ b/pkg/wharfyml/steptype_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestVisitStepType_ErrIfNotMap(t *testing.T) {
 	key, node := getKeyedNode(t, `container: 123`)
-	_, errs := visitStepTypeNode("", key, node, testVarSource{})
+	_, errs := visitStepTypeNode("", key, node, testVarSource)
 	requireContainsErr(t, errs, ErrInvalidFieldType)
 }
 
@@ -14,13 +14,13 @@ func TestVisitStepType_ErrIfInvalidField(t *testing.T) {
 	key, node := getKeyedNode(t, `
 container:
   image: [123]`)
-	_, errs := visitStepTypeNode("", key, node, testVarSource{})
+	_, errs := visitStepTypeNode("", key, node, testVarSource)
 	requireContainsErr(t, errs, ErrInvalidFieldType)
 }
 
 func TestVisitStepType_ErrIfMissingRequiredField(t *testing.T) {
 	// in "container" step, "cmds" and "image" are required
 	key, node := getKeyedNode(t, `container: {}`)
-	_, errs := visitStepTypeNode("", key, node, testVarSource{})
+	_, errs := visitStepTypeNode("", key, node, testVarSource)
 	requireContainsErr(t, errs, ErrMissingRequired)
 }

--- a/pkg/wharfyml/varsub.go
+++ b/pkg/wharfyml/varsub.go
@@ -14,10 +14,13 @@ var (
 	ErrUnsupportedVarSubType = errors.New("unsupported variable substitution value")
 )
 
+// VarSubNode is a custom varsub variable type that envelops a YAML node.
+// Mostly only used internally inside the wharfyml package.
 type VarSubNode struct {
 	Node *yaml.Node
 }
 
+// String implements the fmt.Stringer interface.
 func (v VarSubNode) String() string {
 	return v.Node.Value
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Refactored to use `varsub.Var` everywhere instead of only the values directly
- Added `varsub.Source.ListVars` method
- Added 'wharf vars' command

## Motivation

The changes got a little out of hand, but the base motivation was to make varsub variables also contain the source where they come from.

The command is only for testing purposes, and the output looks like this:

```console
$ go run ./cmd/wharf vars ./test/kubectl -e myEnv
[INFO ] Found 13 variables from 3 different sources:
	
	git:
	  GIT_BRANCH                 feature/varsub-listing
	  GIT_COMMIT                 5391204111631fd7a2e076b0058d5975e611e7f0
	  GIT_COMMIT_AUTHOR_DATE     2022-04-26T11:08:43+02:00
	  GIT_COMMIT_COMMITTER_DATE  2022-04-26T11:08:43+02:00
	  GIT_COMMIT_SUBJECT         Added 'wharf vars' command
	  GIT_SAFEBRANCH             feature-varsub-listing
	  GIT_TAG
	  REPO_BRANCH                feature/varsub-listing
	  REPO_GROUP                 iver-wharf
	  REPO_NAME                  wharf-cmd
	
	../../../../.wharf-vars.yml:
	  REG_URL  http://harbor.example.com
	
	.wharf-ci.yml, environment "myEnv":
	  namespace  wharf-cmd
	  replicas   1
```
