### PR TITLE
Added completions for --loglevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added `--stage` and `--environment` completions to `wharf run` based on the
   parsed `.wharf-ci.yml` file. (#91)
 
+- Added `--loglevel` completions. (#95)
+
 - Added Git integration by executing `git` locally to obtain current branch,
   commit SHA, tags, etc. (#67, #78)
 

--- a/internal/flagtypes/loglevel.go
+++ b/internal/flagtypes/loglevel.go
@@ -8,12 +8,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// LogLevel is a pflag.Value-compatible logging level flag for wharf-core's
+// logger.Level type.
 type LogLevel logger.Level
 
+// Level is a utility function to return the wharf-core logger.Level value.
 func (l LogLevel) Level() logger.Level {
 	return logger.Level(l)
 }
 
+// Set implements the pflag.Value and fmt.Stringer interfaces.
+// This returns a human-readable representation of the loglevel.
 func (l *LogLevel) String() string {
 	switch l.Level() {
 	case logger.LevelDebug:
@@ -31,6 +36,8 @@ func (l *LogLevel) String() string {
 	}
 }
 
+// Set implements the pflag.Value interface.
+// This parses the loglevel string and updates the loglevel variable.
 func (l *LogLevel) Set(val string) error {
 	newLevel, err := parseLevel(val)
 	if err != nil {
@@ -65,10 +72,13 @@ func parseLevel(lvl string) (logger.Level, error) {
 	}
 }
 
+// Type implements the pflag.Value interface.
+// The value is only used in help text.
 func (l *LogLevel) Type() string {
 	return "loglevel"
 }
 
+// CompleteLogLevel returns completions for the LogLevel type.
 func CompleteLogLevel(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 	// Contains less than actually possible, to not bloat the completions
 	return []string{

--- a/internal/flagtypes/loglevel.go
+++ b/internal/flagtypes/loglevel.go
@@ -1,0 +1,91 @@
+package flagtypes
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/iver-wharf/wharf-core/pkg/logger"
+	"github.com/spf13/cobra"
+)
+
+type LogLevel logger.Level
+
+func (l LogLevel) Level() logger.Level {
+	return logger.Level(l)
+}
+
+func (l *LogLevel) String() string {
+	switch l.Level() {
+	case logger.LevelDebug:
+		return `5, "debug"`
+	case logger.LevelInfo:
+		return `4, "info"`
+	case logger.LevelWarn:
+		return `3, "warn"`
+	case logger.LevelError:
+		return `2, "error"`
+	case logger.LevelPanic:
+		return `1, "panic"`
+	default:
+		return logger.Level(*l).String()
+	}
+}
+
+func (l *LogLevel) Set(val string) error {
+	newLevel, err := parseLevel(val)
+	if err != nil {
+		return err
+	}
+	*l = LogLevel(newLevel)
+	return nil
+}
+
+func parseLevel(lvl string) (logger.Level, error) {
+	// Contains more than the completions, to be more user friendly
+	switch strings.ToLower(lvl) {
+	case "5", "d", "debug", "debugging":
+		return logger.LevelDebug, nil
+	case "4", "i", "info", "information":
+		return logger.LevelInfo, nil
+	case "3", "w", "warn", "warning", "warnings":
+		return logger.LevelWarn, nil
+	case "2", "e", "error", "errors":
+		return logger.LevelError, nil
+	case "1", "p", "panic", "panics":
+		return logger.LevelPanic, nil
+	default:
+		// Errors shouldn't have mutliple lines, but as this is solely for
+		// pflag.Value usage then this is an exception.
+		return logger.LevelDebug, errors.New(`invalid logging level, possible values:
+	5  d  debug  debugging
+	4  i  info   information
+	3  w  warn   warning      warnings
+	2  e  error  errors
+	1  p  panic  panics`)
+	}
+}
+
+func (l *LogLevel) Type() string {
+	return "loglevel"
+}
+
+func CompleteLogLevel(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	// Contains less than actually possible, to not bloat the completions
+	return []string{
+		"5\tIncludes all logs",
+		"d\tIncludes all logs",
+		"debug\tIncludes all logs",
+		"4\tIncludes INFO, WARN, ERROR, and PANIC logs (default)",
+		"i\tIncludes INFO, WARN, ERROR, and PANIC logs (default)",
+		"info\tIncludes INFO, WARN, ERROR, and PANIC logs (default)",
+		"3\tIncludes WARN, ERROR, and PANIC logs",
+		"w\tIncludes WARN, ERROR, and PANIC logs",
+		"warn\tIncludes WARN, ERROR, and PANIC logs",
+		"2\tIncludes ERROR, and PANIC logs",
+		"e\tIncludes ERROR, and PANIC logs",
+		"error\tIncludes ERROR, and PANIC logs",
+		"1\tSilent, except for PANIC logs",
+		"p\tSilent, except for PANIC logs",
+		"panic\tSilent, except for PANIC logs",
+	}, cobra.ShellCompDirectiveNoFileComp
+}


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Moved loglevel to a custom `pflag.Value` type into new package `internal/flagtypes`
- Added completions for `--loglevel`

## Motivation

Quality of life feature, and moves the code to a separate package to clean up `cmd/wharf` a little
