### PR TITLE
Added OS env varsub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
     CHART_REPO: http://harbor.example.com
   ```
 
+- Added support for using OS environment variables prefixed with `WHARF_VAR_`
+  in variable substitution, where `WHARF_VAR_REG_URL` would set the `REG_URL`
+  Wharf variable. (#96)
+
 - Added variable substitution support for referenced files in `kubectl` and
   `helm` step types. (#89)
 

--- a/cmd/wharf/run.go
+++ b/cmd/wharf/run.go
@@ -177,6 +177,8 @@ func parseBuildDefinition(currentDir string, ymlArgs wharfyml.Args) (wharfyml.De
 		varSources = append(varSources, gitStats)
 	}
 
+	varSources = append(varSources, varsub.NewOSEnvSource("WHARF_VAR_"))
+
 	ymlArgs.VarSource = varSources
 
 	ymlPath := filepath.Join(currentDir, ".wharf-ci.yml")

--- a/cmd/wharf/run.go
+++ b/cmd/wharf/run.go
@@ -251,7 +251,7 @@ Wharf look for values in the following files:`)
 Wharf also looks for:
   - All ".wharf-vars.yml" in this directory or any parent directory.
   - Local Git repository and extracts GIT_ and REPO_ variables from it.
-  - Environment variables.
+  - Environment variables, with prefix WHARF_VAR_ removed from them.
 
 Sample file content:
   # .wharf-vars.yml

--- a/pkg/varsub/osenvsource.go
+++ b/pkg/varsub/osenvsource.go
@@ -1,0 +1,57 @@
+package varsub
+
+import (
+	"os"
+	"strings"
+)
+
+const osEnvSourceName = "OS environment variables"
+
+// NewOSEnvSource creates a new Source that uses your OS environment variables
+// with a prefix as variables.
+//
+// To use all environment variables, you can specify an empty string as prefix.
+func NewOSEnvSource(prefix string) Source {
+	return osEnvSource{prefix}
+}
+
+type osEnvSource struct {
+	prefix string
+}
+
+// Lookup tries to look up a value based on name and returns that value as
+// well as true on success, or false if the variable was not found.
+func (s osEnvSource) Lookup(name string) (Var, bool) {
+	val, ok := os.LookupEnv(s.prefix + name)
+	if !ok {
+		return Var{}, false
+	}
+	return Var{
+		Key:    name,
+		Value:  val,
+		Source: osEnvSourceName,
+	}, true
+}
+
+// ListVars will return a slice of all variables that this varsub Source
+// provides.
+func (s osEnvSource) ListVars() []Var {
+	var vars []Var
+	for _, env := range os.Environ() {
+		key, val, ok := strings.Cut(env, "=")
+		if !ok {
+			continue
+		}
+		trimmedKey := strings.TrimPrefix(key, s.prefix)
+		if len(trimmedKey) == len(key) {
+			// No prefix was trimmed. It didn't have the prefix
+			continue
+		}
+		vars = append(vars, Var{
+			Key:    trimmedKey,
+			Value:  val,
+			Source: osEnvSourceName,
+		})
+	}
+	return vars
+}

--- a/pkg/varsub/osenvsource_test.go
+++ b/pkg/varsub/osenvsource_test.go
@@ -1,0 +1,42 @@
+package varsub
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOSEnvSource(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("MY_ENV_VAR", "should not find this value")
+	os.Setenv("WHARF_VAR_MY_ENV_VAR", "my value")
+
+	s := NewOSEnvSource("WHARF_VAR_")
+
+	myEnvVar, ok := s.Lookup("MY_ENV_VAR")
+	require.True(t, ok)
+	assert.Equal(t, "my value", myEnvVar.Value)
+}
+
+func TestOSEnvSource_ListVars(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("WHARF_VAR_MY_ENV_VAR", "my value")
+	os.Setenv("WHARF_VAR_MY_OTHER_ENV_VAR", "my other value")
+
+	s := NewOSEnvSource("WHARF_VAR_")
+
+	envVars := s.ListVars()
+	var got []string
+	for _, envVar := range envVars {
+		got = append(got, fmt.Sprintf("%s=%v", envVar.Key, envVar.Value))
+	}
+
+	want := []string{
+		"MY_ENV_VAR=my value",
+		"MY_OTHER_ENV_VAR=my other value",
+	}
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added OS env vars as source, given prefix `WHARF_VAR_`
- Updated "missing variable" env var log

## Motivation

Using prefix `WHARF_VAR_` instead of simply `WHARF_` or even without any prefix because:

- Don't want to pollute the variables used in potential logs and in `wharf vars` output
- Security aspect: Users could otherwise steal potentially secret values from your environment variables
- Doesn't collide with our config values that we use in e.g wharf-api (and that we'll probably want to add to wharf-cmd as well), that has just `WHARF_` as prefix

Closes #92

## Preview

![image](https://user-images.githubusercontent.com/2477952/165316122-fdc6136f-099d-4835-b117-0b24a66c9136.png)
