### PR TITLE
`wharf vars`: Hide overridden variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added new implementation for `wharf run`. (#33, #45, #66, #84)
 
 - Added "vars" command `wharf vars` that prints out all the variables that
-  would be used in a `wharf run` invocation. (#93)
+  would be used in a `wharf run` invocation. (#93, #98)
 
 - Added support for `.gitignore` ignored files and directories when transferring
   repo in `wharf run`. Can be disabled via new `--no-gitignore` flag. (#85)

--- a/pkg/wharfyml/builtins.go
+++ b/pkg/wharfyml/builtins.go
@@ -137,7 +137,7 @@ func useShorthandHomePrefix(path, home string) string {
 // Returned paths include the filename.
 //
 // The ordering of the returned filenames are in the order of which file should
-// have priority over the other, with the highest priority, and file that should
+// have priority over the other; with the file of highest priority that should
 // override all the others, first.
 func ListPossibleVarsFiles(currentDir string) []VarFile {
 	varFiles := listParentDirsPossibleVarsFiles(currentDir)

--- a/pkg/wharfyml/builtins.go
+++ b/pkg/wharfyml/builtins.go
@@ -142,8 +142,6 @@ func useShorthandHomePrefix(path, home string) string {
 func ListPossibleVarsFiles(currentDir string) []VarFile {
 	varFiles := listParentDirsPossibleVarsFiles(currentDir)
 
-	varFiles = append(varFiles, listOSPossibleVarsFiles()...)
-
 	confDir, err := os.UserConfigDir()
 	if err == nil {
 		varFiles = append(varFiles, VarFile{
@@ -151,6 +149,8 @@ func ListPossibleVarsFiles(currentDir string) []VarFile {
 			IsRel: false,
 		})
 	}
+
+	varFiles = append(varFiles, listOSPossibleVarsFiles()...)
 
 	return varFiles
 }

--- a/pkg/wharfyml/builtins_test.go
+++ b/pkg/wharfyml/builtins_test.go
@@ -18,11 +18,11 @@ func TestListParentDirsPossibleBuiltinVarsFiles(t *testing.T) {
 	currentDir := "/home/root/repos/my-repo"
 	varFiles := listParentDirsPossibleVarsFiles(currentDir)
 	want := []string{
-		"/.wharf-vars.yml",
-		"/home/.wharf-vars.yml",
-		"/home/root/.wharf-vars.yml",
-		"/home/root/repos/.wharf-vars.yml",
 		"/home/root/repos/my-repo/.wharf-vars.yml",
+		"/home/root/repos/.wharf-vars.yml",
+		"/home/root/.wharf-vars.yml",
+		"/home/.wharf-vars.yml",
+		"/.wharf-vars.yml",
 	}
 	got := make([]string, len(varFiles))
 	for i, f := range varFiles {


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed `pkg/wharfyml` to include all `.wharf-vars.yml` files as separate `varsub.Source`'s.
- Changed `wharf vars` output to differentiate between used/overridden vars.
- Added colored output B)

## Motivation

Late hours, this is just for the fun of it. The color scheme was chosen by Maria.

This is using the same color library that wharf-core's logger uses, so it does support Windows and automatically removes the ASNI color codes if the output is piped to another command

## Preview

![image](https://user-images.githubusercontent.com/2477952/165331061-a81185f6-53cd-45d4-b431-ad9f27459e13.png)
