### PR TITLE
Fixed `wharf vars` panicing on hidden values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added new implementation for `wharf run`. (#33, #45, #66, #84)
 
 - Added "vars" command `wharf vars` that prints out all the variables that
-  would be used in a `wharf run` invocation. (#93, #98)
+  would be used in a `wharf run` invocation. (#93, #98, #102)
 
 - Added support for `.gitignore` ignored files and directories when transferring
   repo in `wharf run`. Can be disabled via new `--no-gitignore` flag. (#85)

--- a/cmd/wharf/vars.go
+++ b/cmd/wharf/vars.go
@@ -121,17 +121,19 @@ environment variables, such as:
 
 			longestSpaces := strings.Repeat(" ", longestKeyLength+2)
 			for _, v := range vars {
+				if !varsFlags.showAll && !v.isUsed {
+					continue
+				}
 				spacesCount := longestKeyLength - utf8.RuneCountInString(v.Key) + 2
 				spaces := longestSpaces[:spacesCount]
-				if varsFlags.showAll && !v.isUsed {
-					sb.WriteString("  ")
-					colorVarOverridden.Fprintf(&sb, "%s%s%s\n", v.Key, spaces, v.Value)
-				} else if v.isUsed {
-					sb.WriteString("  ")
+				sb.WriteString("  ")
+				if v.isUsed {
 					fmt.Fprintf(&sb, "%s%s%s\n",
 						colorVarKey.Sprint(v.Key),
 						spaces,
 						colorVarValue.Sprint(v.Value))
+				} else {
+					colorVarOverridden.Fprintf(&sb, "%s%s%s\n", v.Key, spaces, v.Value)
 				}
 			}
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed panic in `wharf vars`

## Motivation

It was calculating the spaces to use, even though it wasen't going to be printed, leading to it trying to take a slice of `longestSpaces[:-8]`, which obviously paniced
