### PR TITLE
Added completion to `--input key=value` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added input variables support using the `inputs` field in `.wharf-ci.yml`
   files, and the `--input, -i` flag to `wharf run` and `wharf vars` commands
-  through the CLI, ex: (#97)
+  through the CLI, ex: (#97, #111)
 
   ```sh
   wharf run --input myInputVar=myValue

--- a/cmd/wharf/run.go
+++ b/cmd/wharf/run.go
@@ -296,6 +296,7 @@ func init() {
 	runCmd.Flags().BoolVar(&runFlags.serve, "serve", false, "Serves build results over REST & gRPC and waits until terminated (e.g via SIGTERM)")
 	runCmd.Flags().BoolVar(&runFlags.noGitIgnore, "no-gitignore", false, "Don't respect .gitignore files")
 	runCmd.Flags().VarP(&runFlags.inputs, "input", "i", "Inputs (--input key=value), can be set multiple times")
+	runCmd.RegisterFlagCompletionFunc("input", completeWharfYmlInputs)
 
 	addKubernetesFlags(runCmd.Flags(), &runFlags.k8sOverrides)
 }
@@ -322,6 +323,18 @@ func completeWharfYmlEnv(cmd *cobra.Command, args []string, _ string) ([]string,
 		envs = append(envs, env)
 	}
 	return envs, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeWharfYmlInputs(cmd *cobra.Command, args []string, completed string) ([]string, cobra.ShellCompDirective) {
+	def, err := parseWharfYmlForCompletions(cmd, args)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	var inputs []string
+	for _, input := range def.Inputs {
+		inputs = append(inputs, input.InputVarName())
+	}
+	return flagtypes.CompleteKeyValue(inputs, completed)
 }
 
 func parseWharfYmlForCompletions(cmd *cobra.Command, args []string) (wharfyml.Definition, error) {

--- a/cmd/wharf/vars.go
+++ b/cmd/wharf/vars.go
@@ -27,4 +27,5 @@ func init() {
 	varsCmd.RegisterFlagCompletionFunc("environment", completeWharfYmlEnv)
 	varsCmd.PersistentFlags().BoolVarP(&varsFlags.showAll, "all", "a", false, "Show overridden variables")
 	varsCmd.PersistentFlags().VarP(&varsFlags.inputs, "input", "i", "Inputs (--input key=value), can be set multiple times")
+	varsCmd.RegisterFlagCompletionFunc("input", completeWharfYmlInputs)
 }

--- a/internal/flagtypes/keyvalue.go
+++ b/internal/flagtypes/keyvalue.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -43,6 +44,21 @@ func (s *KeyValue) Set(val string) error {
 // Type returns the name of this type.
 func (s *KeyValue) Type() string {
 	return "keyvalue"
+}
+
+// CompleteKeyValue returns key=value completions using the given slice of keys.
+func CompleteKeyValue(keys []string, completed string) ([]string, cobra.ShellCompDirective) {
+	if len(keys) == 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	if strings.ContainsRune(completed, '_') {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	withDelimiter := make([]string, len(keys))
+	for i, k := range keys {
+		withDelimiter[i] = k + "="
+	}
+	return withDelimiter, cobra.ShellCompDirectiveNoSpace
 }
 
 // KeyValueArray is a flag type that takes in key=value on each flag value and


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added completion func for `flagtypes.KeyValue`
- Register completion func for `wharf vars --input` and `wharf run --input`

## Motivation

Quality of life feature

Closes #105
