### PR TITLE
Silenced goimports commandline in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,10 @@ lint-fix-md:
 	npx remark . .github -o
 
 lint-go:
+	@echo goimports -d '**/*.go'
 	@goimports -d $(shell git ls-files "*.go")
 	revive -formatter stylish -config revive.toml ./...
 
 lint-fix-go:
+	@echo goimports -d -w '**/*.go'
 	@goimports -d -w $(shell git ls-files "*.go")

--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,8 @@ lint-fix-md:
 	npx remark . .github -o
 
 lint-go:
-	goimports -d $(shell git ls-files "*.go")
+	@goimports -d $(shell git ls-files "*.go")
 	revive -formatter stylish -config revive.toml ./...
 
 lint-fix-go:
-	goimports -d -w $(shell git ls-files "*.go")
+	@goimports -d -w $(shell git ls-files "*.go")


### PR DESCRIPTION
## Summary

- Silenced `goimports` commandline

## Motivation

Before:

```console
$ make lint-go
goimports -d api/workerapi/v1/worker.pb.go api/workerapi/v1/worker_grpc.pb.go cmd/wharf/aggregator.go cmd/wharf/aggregator_serve.go cmd/wharf/logger.go cmd/wharf/main.go cmd/wharf/provisioner.go cmd/wharf/provisioner_create.go cmd/wharf/provisioner_delete.go cmd/wharf/provisioner_list.go cmd/wharf/provisioner_serve.go cmd/wharf/root.go cmd/wharf/run.go cmd/wharf/vars.go cmd/wharf/vars_list.go cmd/wharf/vars_substitute.go cmd/wharf/watchdog.go cmd/wharf/watchdog_serve.go internal/filecopy/filecopy.go internal/flagtypes/keyvalue.go internal/flagtypes/loglevel.go internal/gitutil/gitignorer.go internal/gitutil/gitignorer_test.go internal/gitutil/gitutil.go internal/gitutil/stats.go internal/gitutil/stats_test.go internal/ignorer/ignorer.go internal/ignorer/ignorer_test.go internal/parallel/parallel.go internal/tarutil/dir.go internal/tarutil/dir_test.go pkg/aggregator/aggregator.go pkg/aggregator/k8saggregator.go pkg/aggregator/k8saggregator_test.go pkg/provisioner/k8sprovisioner.go pkg/provisioner/provisioner.go pkg/provisioner/worker.go pkg/provisioner/worker_test.go pkg/provisionerapi/provisionerapi.go pkg/provisionerapi/worker.go pkg/provisionerclient/provisionerclient.go pkg/provisionerclient/provisionerclient_test.go pkg/resultstore/artifact.go pkg/resultstore/artifact_test.go pkg/resultstore/fs.go pkg/resultstore/fs_test.go pkg/resultstore/logline.go pkg/resultstore/logline_bench_test.go pkg/resultstore/logline_test.go pkg/resultstore/loglinereader.go pkg/resultstore/loglinereader_test.go pkg/resultstore/loglinewriter.go pkg/resultstore/loglinewriter_test.go pkg/resultstore/resultstore.go pkg/resultstore/resultstore_test.go pkg/resultstore/status.go pkg/resultstore/status_test.go pkg/resultstore/syncset.go pkg/tarstore/tarstore.go pkg/varsub/copier.go pkg/varsub/copier_test.go pkg/varsub/osenvsource.go pkg/varsub/osenvsource_test.go pkg/varsub/source.go pkg/varsub/varsub.go pkg/varsub/varsub_test.go pkg/watchdog/watchdog.go pkg/watchdog/watchdog_test.go pkg/wharfyml/builtins.go pkg/wharfyml/builtins_linux.go pkg/wharfyml/builtins_other.go pkg/wharfyml/builtins_test.go pkg/wharfyml/definition.go pkg/wharfyml/doc.go pkg/wharfyml/environment.go pkg/wharfyml/environment_test.go pkg/wharfyml/error.go pkg/wharfyml/error_test.go pkg/wharfyml/inputs.go pkg/wharfyml/inputs_test.go pkg/wharfyml/inputtypes.go pkg/wharfyml/magicstrings.go pkg/wharfyml/nodemapparser.go pkg/wharfyml/parse.go pkg/wharfyml/parse_test.go pkg/wharfyml/position.go pkg/wharfyml/stage.go pkg/wharfyml/stage_test.go pkg/wharfyml/step.go pkg/wharfyml/step_test.go pkg/wharfyml/steptype.go pkg/wharfyml/steptype_container.go pkg/wharfyml/steptype_docker.go pkg/wharfyml/steptype_helm.go pkg/wharfyml/steptype_helmpackage.go pkg/wharfyml/steptype_kubectl.go pkg/wharfyml/steptype_nugetpackage.go pkg/wharfyml/steptype_test.go pkg/wharfyml/varsub.go pkg/wharfyml/visitor.go pkg/wharfyml/wharfyml.go pkg/worker/builder.go pkg/worker/builder_test.go pkg/worker/context.go pkg/worker/k8spodtemplating.go pkg/worker/k8spodtemplating_test.go pkg/worker/k8srunner.go pkg/worker/nopio.go pkg/worker/stagerunner.go pkg/worker/stagerunner_test.go pkg/worker/status_test.go pkg/worker/worker.go pkg/worker/workermodel/artifact.go pkg/worker/workermodel/status.go pkg/workerapi/workerclient/grpcclient.go pkg/workerapi/workerclient/grpcclient_test.go pkg/workerapi/workerclient/restclient.go pkg/workerapi/workerclient/restclient_test.go pkg/workerapi/workerclient/workerclient.go pkg/workerapi/workerclient/workerclient_test.go pkg/workerapi/workerserver/artifact.go pkg/workerapi/workerserver/grpcserver.go pkg/workerapi/workerserver/restserver.go pkg/workerapi/workerserver/server.go version.go
revive -formatter stylish -config revive.toml ./...
```

After:

```console
$ make lint-go
goimports -d **/*.go
revive -formatter stylish -config revive.toml ./...
```

The output from goimports is still printed. I've only silenced the logging of the command itself.
