### PR TITLE
Added query params for the provisioner

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+
+**/.git
+**/.gitignore
+**/.wharf-ci.yml
+**/.dockerignore
+**/Dockerfile
+**/*.swp
+**/*.exe
+node_modules
+package-lock.json
+**/docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v0.8.0 (WIP)
 
-- Added provisioner commands: (#46, #59)
+- Added provisioner commands: (#46, #59, #117)
 
   - `wharf provisioner serve` that launches an HTTP REST api server with
     endpoints:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - `wharf provisioner serve` that launches an HTTP REST api server with
     endpoints:
 
-    - `GET /api` to check health.
+    - `GET /` to ping.
 
     - `GET /api/swagger/index.html` Swagger generated documentation.
 
@@ -162,8 +162,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added gRPC client in `pkg/workerapi/workerclient` to interface with a worker
   gRPC server. (#51)
 
-- Added HTTP server for worker in `pkg/workerapi/workerserver`: (#51, #114)
+- Added HTTP server for worker in `pkg/workerapi/workerserver`:
+  (#51, #114, #117)
 
+  - `GET /` to ping.
+  - `GET /api/swagger/index.html` Swagger generated documentation.
   - `GET /api/artifact/:artifactId/download` Downloads an artifact.
 
 - Added HTTP client in `pkg/workerapi/workerclient` to interface with

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,13 @@ ARG BUILD_DATE=""
 RUN chmod +x scripts/update-version.sh  \
     && scripts/update-version.sh assets/version.yaml \
     && make swag check \
-    && CGO_ENABLED=0 go build -o main
+    && CGO_ENABLED=0 go build -o wharf ./cmd/wharf
 
 ARG REG=docker.io
 FROM ${REG}/library/alpine:3.15 AS final
 RUN apk add --no-cache ca-certificates tzdata
-WORKDIR /app
-COPY --from=build /src/main ./
-ENTRYPOINT ["/app/main"]
+COPY --from=build /src/wharf /usr/local/bin/wharf
+ENTRYPOINT ["/usr/local/bin/wharf"]
 
 ARG BUILD_VERSION
 ARG BUILD_GIT_COMMIT

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ deps-go:
 deps-npm:
 	npm install
 
-check:
+check: swag
 	go test ./...
 
 proto:

--- a/Makefile
+++ b/Makefile
@@ -65,25 +65,28 @@ docker-run:
 	docker run --rm -it quay.io/iver-wharf/wharf-api:$(version)
 
 clean-swag:
-	rm -vf pkg/provisionerapi/docs/docs.go
-	rm -vf pkg/workerapi/workerserver/docs/docs.go
+	rm -vrf pkg/provisionerapi/docs pkg/workerapi/workerserver/docs
 
 swag-force: clean-swag swag
 
 swag: \
-	pkg/provisionerapi/docs/docs.go \
-	pkg/workerapi/workerserver/docs/docs.go
+	pkg/provisionerapi/docs \
+	pkg/workerapi/workerserver/docs
 
-pkg/provisionerapi/docs/docs.go:
+pkg/provisionerapi/docs:
 	swag init \
 		--dir pkg/provisionerapi,pkg/provisioner,pkg/worker \
-		--generalInfo provisionerapi.go --output pkg/provisionerapi/docs
+		--generalInfo provisionerapi.go \
+		--output pkg/provisionerapi/docs \
+		--instanceName provisionerapi
 
-pkg/workerapi/workerserver/docs/docs.go:
+pkg/workerapi/workerserver/docs:
 	swag init \
 		--dir pkg/workerapi/workerserver \
 		--parseDependency --parseDepth 2 \
-		--generalInfo restserver.go --output pkg/workerapi/workerserver/docs
+		--generalInfo restserver.go \
+		--output pkg/workerapi/workerserver/docs \
+		--instanceName workerapi
 
 lint: lint-md lint-go
 lint-fix: lint-fix-md lint-fix-go

--- a/cmd/wharf/provisioner.go
+++ b/cmd/wharf/provisioner.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/iver-wharf/wharf-cmd/pkg/provisioner"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -11,7 +12,18 @@ var provisionerFlags = struct {
 
 	restConfig *rest.Config
 	namespace  string
-}{}
+
+	instanceID string
+}{
+	instanceID: "local",
+}
+
+func newProvisioner() (provisioner.Provisioner, error) {
+	return provisioner.NewK8sProvisioner(
+		provisionerFlags.instanceID,
+		provisionerFlags.namespace,
+		provisionerFlags.restConfig)
+}
 
 var provisionerCmd = &cobra.Command{
 	Use:   "provisioner",
@@ -41,5 +53,6 @@ orchestration is handled inside the Kubernetes cluster, in comparison to the
 func init() {
 	rootCmd.AddCommand(provisionerCmd)
 
+	provisionerCmd.Flags().StringVar(&provisionerFlags.instanceID, "instance", provisionerFlags.instanceID, "Wharf instance ID, used to avoid collisions in Pod ownership.")
 	addKubernetesFlags(provisionerCmd.PersistentFlags(), &provisionerFlags.k8sOverrides)
 }

--- a/cmd/wharf/provisioner_create.go
+++ b/cmd/wharf/provisioner_create.go
@@ -1,23 +1,42 @@
 package main
 
 import (
+	"github.com/iver-wharf/wharf-cmd/internal/flagtypes"
 	"github.com/iver-wharf/wharf-cmd/pkg/provisioner"
 	"github.com/spf13/cobra"
 )
 
+var provisionerCreateFlags = struct {
+	stage  string
+	env    string
+	subdir string
+	inputs flagtypes.KeyValueArray
+}{}
+
 var provisionerCreateCmd = &cobra.Command{
-	Use:   "create",
+	Use:   "create <repo>",
 	Short: "Starts a build via a new worker inside a Kubernetes pod",
 	Long: `Creates a new Kubernetes pod that clones a Git repo and
 a container running "wharf run" to perform the build.
-`,
+
+The <repo> argument is used by Git to clone the repository, such as:
+
+  wharf provisioner create https://github.com/iver-wharf/wharf-cmd
+  wharf provisioner create ssh://git@github.com/iver-wharf/wharf-cmd.git`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		p, err := provisioner.NewK8sProvisioner(provisionerFlags.namespace, provisionerFlags.restConfig)
 		if err != nil {
 			return err
 		}
 
-		worker, err := p.CreateWorker(rootContext, provisioner.WorkerArgs{})
+		worker, err := p.CreateWorker(rootContext, provisioner.WorkerArgs{
+			GitCloneURL: args[0],
+			SubDir:      provisionerCreateFlags.subdir,
+			Inputs:      parseInputArgs(provisionerCreateFlags.inputs),
+			Environment: provisionerCreateFlags.env,
+			Stage:       provisionerCreateFlags.stage,
+		})
 		if err != nil {
 			return err
 		}
@@ -32,4 +51,11 @@ a container running "wharf run" to perform the build.
 
 func init() {
 	provisionerCmd.AddCommand(provisionerCreateCmd)
+	provisionerCreateCmd.Flags().StringVarP(&provisionerCreateFlags.stage, "stage", "s", "", "Stage to run (will run all stages if unset)")
+	provisionerCreateCmd.RegisterFlagCompletionFunc("stage", completeWharfYmlStage)
+	provisionerCreateCmd.Flags().StringVarP(&provisionerCreateFlags.env, "environment", "e", "", "Environment selection")
+	provisionerCreateCmd.RegisterFlagCompletionFunc("environment", completeWharfYmlEnv)
+	provisionerCreateCmd.Flags().VarP(&provisionerCreateFlags.inputs, "input", "i", "Inputs (--input key=value), can be set multiple times")
+	provisionerCreateCmd.RegisterFlagCompletionFunc("input", completeWharfYmlInputs)
+	provisionerCreateCmd.Flags().StringVar(&provisionerCreateFlags.subdir, "subdir", "", "Subdirectory of repository where .wharf-ci.yml file is found.")
 }

--- a/cmd/wharf/provisioner_create.go
+++ b/cmd/wharf/provisioner_create.go
@@ -17,7 +17,7 @@ a container running "wharf run" to perform the build.
 			return err
 		}
 
-		worker, err := p.CreateWorker(rootContext)
+		worker, err := p.CreateWorker(rootContext, provisioner.WorkerArgs{})
 		if err != nil {
 			return err
 		}

--- a/cmd/wharf/provisioner_create.go
+++ b/cmd/wharf/provisioner_create.go
@@ -51,11 +51,10 @@ The <repo> argument is used by Git to clone the repository, such as:
 
 func init() {
 	provisionerCmd.AddCommand(provisionerCreateCmd)
-	provisionerCreateCmd.Flags().StringVarP(&provisionerCreateFlags.stage, "stage", "s", "", "Stage to run (will run all stages if unset)")
-	provisionerCreateCmd.RegisterFlagCompletionFunc("stage", completeWharfYmlStage)
-	provisionerCreateCmd.Flags().StringVarP(&provisionerCreateFlags.env, "environment", "e", "", "Environment selection")
-	provisionerCreateCmd.RegisterFlagCompletionFunc("environment", completeWharfYmlEnv)
-	provisionerCreateCmd.Flags().VarP(&provisionerCreateFlags.inputs, "input", "i", "Inputs (--input key=value), can be set multiple times")
-	provisionerCreateCmd.RegisterFlagCompletionFunc("input", completeWharfYmlInputs)
+
 	provisionerCreateCmd.Flags().StringVar(&provisionerCreateFlags.subdir, "subdir", "", "Subdirectory of repository where .wharf-ci.yml file is found.")
+
+	addWharfYmlStageFlag(provisionerCreateCmd, &provisionerCreateFlags.stage)
+	addWharfYmlEnvFlag(provisionerCreateCmd, &provisionerCreateFlags.env)
+	addWharfYmlInputsFlag(provisionerCreateCmd, &provisionerCreateFlags.inputs)
 }

--- a/cmd/wharf/provisioner_create.go
+++ b/cmd/wharf/provisioner_create.go
@@ -25,7 +25,7 @@ The <repo> argument is used by Git to clone the repository, such as:
   wharf provisioner create ssh://git@github.com/iver-wharf/wharf-cmd.git`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		p, err := provisioner.NewK8sProvisioner(provisionerFlags.namespace, provisionerFlags.restConfig)
+		p, err := newProvisioner()
 		if err != nil {
 			return err
 		}

--- a/cmd/wharf/provisioner_delete.go
+++ b/cmd/wharf/provisioner_delete.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/iver-wharf/wharf-cmd/pkg/provisioner"
 	"github.com/spf13/cobra"
 )
 
@@ -12,7 +11,7 @@ var provisionerDeleteCmd = &cobra.Command{
 	Long: `Terminates a wharf worker pod in Kubernetes, effectively
 cancelling the build.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		p, err := provisioner.NewK8sProvisioner(provisionerFlags.namespace, provisionerFlags.restConfig)
+		p, err := newProvisioner()
 		if err != nil {
 			return err
 		}

--- a/cmd/wharf/provisioner_list.go
+++ b/cmd/wharf/provisioner_list.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/iver-wharf/wharf-cmd/pkg/provisioner"
 	"github.com/spf13/cobra"
 )
 
@@ -11,7 +10,7 @@ var provisionerListCmd = &cobra.Command{
 	Long: `Lists wharf worker pods inside Kubernetes
 that are either scheduling, running, or completed.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		p, err := provisioner.NewK8sProvisioner(provisionerFlags.namespace, provisionerFlags.restConfig)
+		p, err := newProvisioner()
 		if err != nil {
 			return err
 		}

--- a/cmd/wharf/provisioner_serve.go
+++ b/cmd/wharf/provisioner_serve.go
@@ -18,7 +18,11 @@ the following URL path on a running wharf provisioner server:
 	/api/swagger/index.html
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return provisionerapi.Serve(provisionerFlags.namespace, provisionerFlags.restConfig)
+		prov, err := newProvisioner()
+		if err != nil {
+			return err
+		}
+		return provisionerapi.Serve(prov)
 	},
 }
 

--- a/cmd/wharf/run.go
+++ b/cmd/wharf/run.go
@@ -4,16 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/iver-wharf/wharf-cmd/internal/flagtypes"
-	"github.com/iver-wharf/wharf-cmd/internal/gitutil"
 	"github.com/iver-wharf/wharf-cmd/pkg/resultstore"
 	"github.com/iver-wharf/wharf-cmd/pkg/tarstore"
-	"github.com/iver-wharf/wharf-cmd/pkg/varsub"
 	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml"
 	"github.com/iver-wharf/wharf-cmd/pkg/worker"
 	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
@@ -141,81 +136,6 @@ https://iver-wharf.github.io/#/usage-wharfyml/`,
 	},
 }
 
-func parseCurrentDir(dirArg string) (string, error) {
-	if dirArg == "" {
-		return os.Getwd()
-	}
-	abs, err := filepath.Abs(dirArg)
-	if err != nil {
-		return "", err
-	}
-	stat, err := os.Stat(abs)
-	if err != nil {
-		return "", err
-	}
-	if !stat.IsDir() {
-		dir, file := filepath.Split(abs)
-		if file == ".wharf-ci.yml" {
-			return filepath.Clean(dir), nil
-		}
-		return "", fmt.Errorf("path is neither a dir nor a .wharf-ci.yml file: %s", abs)
-	}
-	_, err = os.Stat(filepath.Join(abs, ".wharf-ci.yml"))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "", fmt.Errorf("missing .wharf-ci.yml file in dir: %s", abs)
-		}
-		return "", err
-	}
-	return abs, nil
-}
-
-func parseBuildDefinition(currentDir string, ymlArgs wharfyml.Args) (wharfyml.Definition, error) {
-	var varSources varsub.SourceSlice
-	if ymlArgs.VarSource != nil {
-		varSources = append(varSources, ymlArgs.VarSource)
-	}
-
-	varSources = append(varSources, varsub.NewOSEnvSource("WHARF_VAR_"))
-
-	varFileSource, errs := wharfyml.ParseVarFiles(currentDir)
-	if len(errs) > 0 {
-		logParseErrors(errs, currentDir)
-		return wharfyml.Definition{}, errors.New("failed to parse variable files")
-	}
-	varSources = append(varSources, varFileSource)
-
-	gitStats, err := gitutil.StatsFromExec(currentDir)
-	if err != nil {
-		log.Warn().WithError(err).
-			Message("Failed to get REPO_ and GIT_ variables from Git. Skipping those.")
-	} else {
-		log.Debug().Message("Read REPO_ and GIT_ variables from Git:\n" +
-			gitStats.String())
-		varSources = append(varSources, gitStats)
-	}
-
-	ymlArgs.VarSource = varSources
-
-	ymlPath := filepath.Join(currentDir, ".wharf-ci.yml")
-	log.Debug().WithString("path", ymlPath).Message("Parsing .wharf-ci.yml file.")
-	def, errs := wharfyml.ParseFile(ymlPath, ymlArgs)
-	if len(errs) > 0 {
-		logParseErrors(errs, currentDir)
-		return wharfyml.Definition{}, errors.New("failed to parse .wharf-ci.yml")
-	}
-	log.Debug().Message("Successfully parsed .wharf-ci.yml")
-	return def, nil
-}
-
-func parseInputArgs(inputs flagtypes.KeyValueArray) map[string]any {
-	m := make(map[string]any, len(inputs.Pairs))
-	for _, kv := range inputs.Pairs {
-		m[kv.Key] = kv.Value
-	}
-	return m
-}
-
 func startWorkerServerWithCancel(ctx context.Context, store resultstore.Store) (context.Context, workerserver.Server) {
 	ctx, cancel := context.WithCancel(ctx)
 	server := workerserver.New(store, nil)
@@ -238,123 +158,14 @@ func startWorkerServerWithCancel(ctx context.Context, store resultstore.Store) (
 	return ctx, server
 }
 
-func logParseErrors(errs wharfyml.Errors, currentDir string) {
-	log.Warn().WithInt("errors", len(errs)).Message("Cannot run build due to parsing errors.")
-	for _, err := range errs {
-		var posErr wharfyml.PosError
-		if errors.As(err, &posErr) {
-			log.Warn().Messagef("%4d:%-4d%s",
-				posErr.Source.Line, posErr.Source.Column, err.Error())
-		} else {
-			log.Warn().Messagef("   -:-   %s", err.Error())
-		}
-	}
-
-	containsMissingBuiltin := false
-	for _, err := range errs {
-		if errors.Is(err, wharfyml.ErrMissingBuiltinVar) {
-			containsMissingBuiltin = true
-			break
-		}
-	}
-	if containsMissingBuiltin {
-		varFiles := wharfyml.ListPossibleVarsFiles(currentDir)
-		var sb strings.Builder
-		sb.WriteString(`Tip: You can add built-in variables to Wharf in multiple ways.
-
-Wharf look for values in the following files:`)
-		for _, file := range varFiles {
-			if file.IsRel {
-				continue
-			}
-			sb.WriteString("\n  ")
-			sb.WriteString(file.PrettyPath(currentDir))
-		}
-		sb.WriteString(`
-
-Wharf also looks for:
-  - All ".wharf-vars.yml" in this directory or any parent directory.
-  - Local Git repository and extracts GIT_ and REPO_ variables from it.
-  - Environment variables, with prefix WHARF_VAR_ removed from them.
-
-Sample file content:
-  # .wharf-vars.yml
-  vars:
-    REG_URL: http://harbor.example.com
-`)
-		log.Info().Message(sb.String())
-	}
-}
-
 func init() {
 	rootCmd.AddCommand(runCmd)
 
-	runCmd.Flags().StringVarP(&runFlags.stage, "stage", "s", "", "Stage to run (will run all stages if unset)")
-	runCmd.RegisterFlagCompletionFunc("stage", completeWharfYmlStage)
-	runCmd.Flags().StringVarP(&runFlags.env, "environment", "e", "", "Environment selection")
-	runCmd.RegisterFlagCompletionFunc("environment", completeWharfYmlEnv)
 	runCmd.Flags().BoolVar(&runFlags.serve, "serve", false, "Serves build results over REST & gRPC and waits until terminated (e.g via SIGTERM)")
 	runCmd.Flags().BoolVar(&runFlags.noGitIgnore, "no-gitignore", false, "Don't respect .gitignore files")
-	runCmd.Flags().VarP(&runFlags.inputs, "input", "i", "Inputs (--input key=value), can be set multiple times")
-	runCmd.RegisterFlagCompletionFunc("input", completeWharfYmlInputs)
 
+	addWharfYmlStageFlag(runCmd, &runFlags.stage)
+	addWharfYmlEnvFlag(runCmd, &runFlags.env)
+	addWharfYmlInputsFlag(runCmd, &runFlags.inputs)
 	addKubernetesFlags(runCmd.Flags(), &runFlags.k8sOverrides)
-}
-
-func completeWharfYmlStage(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
-	def, err := parseWharfYmlForCompletions(cmd, args)
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveError
-	}
-	var stages []string
-	for _, stage := range def.Stages {
-		stages = append(stages, stage.Name)
-	}
-	return stages, cobra.ShellCompDirectiveNoFileComp
-}
-
-func completeWharfYmlEnv(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
-	def, err := parseWharfYmlForCompletions(cmd, args)
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveError
-	}
-	var envs []string
-	for env := range def.Envs {
-		envs = append(envs, env)
-	}
-	return envs, cobra.ShellCompDirectiveNoFileComp
-}
-
-func completeWharfYmlInputs(cmd *cobra.Command, args []string, completed string) ([]string, cobra.ShellCompDirective) {
-	def, err := parseWharfYmlForCompletions(cmd, args)
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveError
-	}
-	var inputs []string
-	for _, input := range def.Inputs {
-		inputs = append(inputs, input.InputVarName())
-	}
-	return flagtypes.CompleteKeyValue(inputs, completed)
-}
-
-func parseWharfYmlForCompletions(cmd *cobra.Command, args []string) (wharfyml.Definition, error) {
-	currentDir, err := parseCurrentDir(slices.SafeGet(args, 0))
-	if err != nil {
-		return wharfyml.Definition{}, err
-	}
-
-	var ymlArgs wharfyml.Args
-	envFlag := cmd.Flag("environment")
-	if envFlag.Changed {
-		ymlArgs.Env = envFlag.Value.String()
-	} else {
-		ymlArgs.SkipStageFiltering = true
-	}
-
-	ymlPath := filepath.Join(currentDir, ".wharf-ci.yml")
-
-	// Intentionally ignore any parse errors, as syntax errors or missing fields
-	// for a step type are irrelevant for the completions.
-	def, _ := wharfyml.ParseFile(ymlPath, ymlArgs)
-	return def, nil
 }

--- a/cmd/wharf/utils.go
+++ b/cmd/wharf/utils.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/iver-wharf/wharf-cmd/internal/flagtypes"
+	"github.com/iver-wharf/wharf-cmd/internal/gitutil"
+	"github.com/iver-wharf/wharf-cmd/pkg/varsub"
+	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml"
+	"github.com/spf13/cobra"
+	"gopkg.in/typ.v3/pkg/slices"
+)
+
+func parseCurrentDir(dirArg string) (string, error) {
+	if dirArg == "" {
+		return os.Getwd()
+	}
+	abs, err := filepath.Abs(dirArg)
+	if err != nil {
+		return "", err
+	}
+	stat, err := os.Stat(abs)
+	if err != nil {
+		return "", err
+	}
+	if !stat.IsDir() {
+		dir, file := filepath.Split(abs)
+		if file == ".wharf-ci.yml" {
+			return filepath.Clean(dir), nil
+		}
+		return "", fmt.Errorf("path is neither a dir nor a .wharf-ci.yml file: %s", abs)
+	}
+	_, err = os.Stat(filepath.Join(abs, ".wharf-ci.yml"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("missing .wharf-ci.yml file in dir: %s", abs)
+		}
+		return "", err
+	}
+	return abs, nil
+}
+
+func parseBuildDefinition(currentDir string, ymlArgs wharfyml.Args) (wharfyml.Definition, error) {
+	var varSources varsub.SourceSlice
+	if ymlArgs.VarSource != nil {
+		varSources = append(varSources, ymlArgs.VarSource)
+	}
+
+	varSources = append(varSources, varsub.NewOSEnvSource("WHARF_VAR_"))
+
+	varFileSource, errs := wharfyml.ParseVarFiles(currentDir)
+	if len(errs) > 0 {
+		logParseErrors(errs, currentDir)
+		return wharfyml.Definition{}, errors.New("failed to parse variable files")
+	}
+	varSources = append(varSources, varFileSource)
+
+	gitStats, err := gitutil.StatsFromExec(currentDir)
+	if err != nil {
+		log.Warn().WithError(err).
+			Message("Failed to get REPO_ and GIT_ variables from Git. Skipping those.")
+	} else {
+		log.Debug().Message("Read REPO_ and GIT_ variables from Git:\n" +
+			gitStats.String())
+		varSources = append(varSources, gitStats)
+	}
+
+	ymlArgs.VarSource = varSources
+
+	ymlPath := filepath.Join(currentDir, ".wharf-ci.yml")
+	log.Debug().WithString("path", ymlPath).Message("Parsing .wharf-ci.yml file.")
+	def, errs := wharfyml.ParseFile(ymlPath, ymlArgs)
+	if len(errs) > 0 {
+		logParseErrors(errs, currentDir)
+		return wharfyml.Definition{}, errors.New("failed to parse .wharf-ci.yml")
+	}
+	log.Debug().Message("Successfully parsed .wharf-ci.yml")
+	return def, nil
+}
+
+func parseInputArgs(inputs flagtypes.KeyValueArray) map[string]any {
+	m := make(map[string]any, len(inputs.Pairs))
+	for _, kv := range inputs.Pairs {
+		m[kv.Key] = kv.Value
+	}
+	return m
+}
+
+func logParseErrors(errs wharfyml.Errors, currentDir string) {
+	log.Warn().WithInt("errors", len(errs)).Message("Cannot run build due to parsing errors.")
+	for _, err := range errs {
+		var posErr wharfyml.PosError
+		if errors.As(err, &posErr) {
+			log.Warn().Messagef("%4d:%-4d%s",
+				posErr.Source.Line, posErr.Source.Column, err.Error())
+		} else {
+			log.Warn().Messagef("   -:-   %s", err.Error())
+		}
+	}
+
+	containsMissingBuiltin := false
+	for _, err := range errs {
+		if errors.Is(err, wharfyml.ErrMissingBuiltinVar) {
+			containsMissingBuiltin = true
+			break
+		}
+	}
+	if containsMissingBuiltin {
+		varFiles := wharfyml.ListPossibleVarsFiles(currentDir)
+		var sb strings.Builder
+		sb.WriteString(`Tip: You can add built-in variables to Wharf in multiple ways.
+
+Wharf look for values in the following files:`)
+		for _, file := range varFiles {
+			if file.IsRel {
+				continue
+			}
+			sb.WriteString("\n  ")
+			sb.WriteString(file.PrettyPath(currentDir))
+		}
+		sb.WriteString(`
+
+Wharf also looks for:
+  - All ".wharf-vars.yml" in this directory or any parent directory.
+  - Local Git repository and extracts GIT_ and REPO_ variables from it.
+  - Environment variables, with prefix WHARF_VAR_ removed from them.
+
+Sample file content:
+  # .wharf-vars.yml
+  vars:
+    REG_URL: http://harbor.example.com
+`)
+		log.Info().Message(sb.String())
+	}
+}
+
+func addWharfYmlStageFlag(cmd *cobra.Command, value *string) {
+	cmd.Flags().StringVarP(value, "stage", "s", "", "Stage to run (will run all stages if unset)")
+	cmd.RegisterFlagCompletionFunc("stage", completeWharfYmlStage)
+}
+
+func addWharfYmlEnvFlag(cmd *cobra.Command, value *string) {
+	cmd.Flags().StringVarP(value, "environment", "e", "", "Environment selection")
+	cmd.RegisterFlagCompletionFunc("environment", completeWharfYmlEnv)
+}
+
+func addWharfYmlInputsFlag(cmd *cobra.Command, value *flagtypes.KeyValueArray) {
+	cmd.Flags().VarP(value, "input", "i", "Inputs (--input key=value), can be set multiple times")
+	cmd.RegisterFlagCompletionFunc("input", completeWharfYmlInputs)
+}
+
+func completeWharfYmlStage(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+	def, err := parseWharfYmlForCompletions(cmd, args)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	var stages []string
+	for _, stage := range def.Stages {
+		stages = append(stages, stage.Name)
+	}
+	return stages, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeWharfYmlEnv(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+	def, err := parseWharfYmlForCompletions(cmd, args)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	var envs []string
+	for env := range def.Envs {
+		envs = append(envs, env)
+	}
+	return envs, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeWharfYmlInputs(cmd *cobra.Command, args []string, completed string) ([]string, cobra.ShellCompDirective) {
+	def, err := parseWharfYmlForCompletions(cmd, args)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	var inputs []string
+	for _, input := range def.Inputs {
+		inputs = append(inputs, input.InputVarName())
+	}
+	return flagtypes.CompleteKeyValue(inputs, completed)
+}
+
+func parseWharfYmlForCompletions(cmd *cobra.Command, args []string) (wharfyml.Definition, error) {
+	currentDir, err := parseCurrentDir(slices.SafeGet(args, 0))
+	if err != nil {
+		return wharfyml.Definition{}, err
+	}
+
+	var ymlArgs wharfyml.Args
+	envFlag := cmd.Flag("environment")
+	if envFlag.Changed {
+		ymlArgs.Env = envFlag.Value.String()
+	} else {
+		ymlArgs.SkipStageFiltering = true
+	}
+
+	ymlPath := filepath.Join(currentDir, ".wharf-ci.yml")
+
+	// Intentionally ignore any parse errors, as syntax errors or missing fields
+	// for a step type are irrelevant for the completions.
+	def, _ := wharfyml.ParseFile(ymlPath, ymlArgs)
+	return def, nil
+}

--- a/cmd/wharf/vars.go
+++ b/cmd/wharf/vars.go
@@ -23,9 +23,8 @@ var varsCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(varsCmd)
 
-	varsCmd.PersistentFlags().StringVarP(&varsFlags.env, "environment", "e", "", "Environment selection")
-	varsCmd.RegisterFlagCompletionFunc("environment", completeWharfYmlEnv)
 	varsCmd.PersistentFlags().BoolVarP(&varsFlags.showAll, "all", "a", false, "Show overridden variables")
-	varsCmd.PersistentFlags().VarP(&varsFlags.inputs, "input", "i", "Inputs (--input key=value), can be set multiple times")
-	varsCmd.RegisterFlagCompletionFunc("input", completeWharfYmlInputs)
+
+	addWharfYmlEnvFlag(varsCmd, &varsFlags.env)
+	addWharfYmlInputsFlag(varsCmd, &varsFlags.inputs)
 }

--- a/pkg/provisioner/k8sprovisioner.go
+++ b/pkg/provisioner/k8sprovisioner.go
@@ -117,7 +117,7 @@ func (p k8sProvisioner) newWorkerPod(args WorkerArgs) v1.Pod {
 	}
 	gitArgs = append(gitArgs, repoVolumeMountPath)
 
-	wharfArgs := []string{"run", "--loglevel", "debug"}
+	wharfArgs := []string{"run", "--loglevel", "debug", "--serve"}
 	if args.Environment != "" {
 		wharfArgs = append(wharfArgs, "--environment", args.Environment)
 	}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -7,7 +7,23 @@ import (
 // Provisioner is an interface declaring what methods are required
 // for a provisioner.
 type Provisioner interface {
-	CreateWorker(ctx context.Context) (Worker, error)
+	CreateWorker(ctx context.Context, args WorkerArgs) (Worker, error)
 	ListWorkers(ctx context.Context) ([]Worker, error)
 	DeleteWorker(ctx context.Context, workerID string) error
+}
+
+// WorkerArgs are arguments fed to the wharf-cmd-worker.
+type WorkerArgs struct {
+	GitCloneURL    string
+	GitCloneBranch string
+
+	Environment string
+	Stage       string
+
+	Inputs         map[string]any
+	AdditionalVars map[string]any
+
+	WharfInstanceID string
+	ProjectID       uint
+	BuildID         uint
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -16,6 +16,7 @@ type Provisioner interface {
 type WorkerArgs struct {
 	GitCloneURL    string
 	GitCloneBranch string
+	SubDir         string
 
 	Environment string
 	Stage       string

--- a/pkg/provisionerapi/.gitignore
+++ b/pkg/provisionerapi/.gitignore
@@ -1,3 +1,2 @@
 # Generated swaggo docs
-docs/docs.go
-docs/swagger.*
+docs/

--- a/pkg/provisionerapi/provisionerapi.go
+++ b/pkg/provisionerapi/provisionerapi.go
@@ -2,13 +2,13 @@ package provisionerapi
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/iver-wharf/wharf-cmd/pkg/provisioner"
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 	"github.com/iver-wharf/wharf-core/pkg/logger"
 	ginSwagger "github.com/swaggo/gin-swagger"
 	"github.com/swaggo/gin-swagger/swaggerFiles"
 
 	// Load in swagger docs
-	"github.com/iver-wharf/wharf-cmd/pkg/provisioner"
 	_ "github.com/iver-wharf/wharf-cmd/pkg/provisionerapi/docs"
 )
 

--- a/pkg/provisionerapi/provisionerapi.go
+++ b/pkg/provisionerapi/provisionerapi.go
@@ -21,7 +21,6 @@ var log = logger.NewScoped("PROVISIONER-API")
 // @contact.name Iver wharf-cmd support
 // @contact.url https://github.com/iver-wharf/wharf-cmd/issues
 // @contact.email wharf@iver.se
-// @basePath /api
 // @query.collection.format multi
 func Serve(prov provisioner.Provisioner) error {
 	gin.DefaultWriter = ginutil.DefaultLoggerWriter
@@ -33,14 +32,13 @@ func Serve(prov provisioner.Provisioner) error {
 		ginutil.RecoverProblem,
 	)
 
-	g := r.Group("/api")
-	g.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, func(c *ginSwagger.Config) {
+	r.GET("", pingHandler)
+	api := r.Group("/api")
+	api.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, func(c *ginSwagger.Config) {
 		c.InstanceName = docs.SwaggerInfoprovisionerapi.InstanceName()
 	}))
-	g.GET("", pingHandler)
 
-	workerModule := workerModule{prov: prov}
-	workerModule.register(g)
+	workerModule{prov: prov}.register(api)
 
 	const bindAddress = "0.0.0.0:5009"
 	log.Info().WithString("address", bindAddress).Message("Starting server.")

--- a/pkg/provisionerapi/provisionerapi.go
+++ b/pkg/provisionerapi/provisionerapi.go
@@ -36,7 +36,9 @@ func Serve(prov provisioner.Provisioner) error {
 	)
 
 	g := r.Group("/api")
-	g.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	g.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, func(c *ginSwagger.Config) {
+		c.InstanceName = "provisionerapi"
+	}))
 	g.GET("", pingHandler)
 
 	workerModule := workerModule{prov: prov}

--- a/pkg/provisionerapi/provisionerapi.go
+++ b/pkg/provisionerapi/provisionerapi.go
@@ -72,6 +72,7 @@ type Ping struct {
 // @description Pong.
 // @description Added in v0.8.0.
 // @tags meta
+// @produce json
 // @success 200 {object} Ping
 // @router / [get]
 func pingHandler(c *gin.Context) {

--- a/pkg/provisionerapi/provisionerapi.go
+++ b/pkg/provisionerapi/provisionerapi.go
@@ -3,13 +3,11 @@ package provisionerapi
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/iver-wharf/wharf-cmd/pkg/provisioner"
+	"github.com/iver-wharf/wharf-cmd/pkg/provisionerapi/docs"
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 	"github.com/iver-wharf/wharf-core/pkg/logger"
 	ginSwagger "github.com/swaggo/gin-swagger"
 	"github.com/swaggo/gin-swagger/swaggerFiles"
-
-	// Load in swagger docs
-	_ "github.com/iver-wharf/wharf-cmd/pkg/provisionerapi/docs"
 )
 
 var log = logger.NewScoped("PROVISIONER-API")
@@ -37,7 +35,7 @@ func Serve(prov provisioner.Provisioner) error {
 
 	g := r.Group("/api")
 	g.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, func(c *ginSwagger.Config) {
-		c.InstanceName = "provisionerapi"
+		c.InstanceName = docs.SwaggerInfoprovisionerapi.InstanceName()
 	}))
 	g.GET("", pingHandler)
 

--- a/pkg/provisionerapi/worker.go
+++ b/pkg/provisionerapi/worker.go
@@ -7,20 +7,10 @@ import (
 	"github.com/iver-wharf/wharf-cmd/pkg/provisioner"
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 	"gopkg.in/yaml.v3"
-	"k8s.io/client-go/rest"
 )
 
 type workerModule struct {
 	prov provisioner.Provisioner
-}
-
-func (m *workerModule) init(ns string, cfg *rest.Config) error {
-	p, err := provisioner.NewK8sProvisioner(ns, cfg)
-	if err != nil {
-		return err
-	}
-	m.prov = p
-	return nil
 }
 
 func (m *workerModule) register(g *gin.RouterGroup) {

--- a/pkg/provisionerapi/worker.go
+++ b/pkg/provisionerapi/worker.go
@@ -13,7 +13,7 @@ type workerModule struct {
 	prov provisioner.Provisioner
 }
 
-func (m *workerModule) register(g *gin.RouterGroup) {
+func (m workerModule) register(g *gin.RouterGroup) {
 	g.GET("/worker", m.listWorkersHandler)
 	g.POST("/worker", m.createWorkerHandler)
 	g.DELETE("/worker/:workerId", m.deleteWorkerHandler)
@@ -27,8 +27,8 @@ func (m *workerModule) register(g *gin.RouterGroup) {
 // @produce json
 // @success 200 {object} []provisioner.Worker
 // @failure 500 {object} string "Failed"
-// @router /worker [get]
-func (m *workerModule) listWorkersHandler(c *gin.Context) {
+// @router /api/worker [get]
+func (m workerModule) listWorkersHandler(c *gin.Context) {
 	workers, err := m.prov.ListWorkers(c.Request.Context())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, err)
@@ -58,8 +58,8 @@ func (m *workerModule) listWorkersHandler(c *gin.Context) {
 // @param WHARF_PROJECT_ID query uint   false "Wharf project ID" minimum(0) example(456)
 // @success 201 {object} provisioner.Worker
 // @failure 500 {object} string "Failed"
-// @router /worker [post]
-func (m *workerModule) createWorkerHandler(c *gin.Context) {
+// @router /api/worker [post]
+func (m workerModule) createWorkerHandler(c *gin.Context) {
 	var params = struct {
 		BuildRef       uint   `form:"BUILD_REF"`
 		Environment    string `form:"ENVIRONMENT"`
@@ -131,8 +131,8 @@ func (m *workerModule) createWorkerHandler(c *gin.Context) {
 // @param workerId path uint true "ID of worker to delete" minimum(0)
 // @success 204 "OK"
 // @failure 500 {object} string "Failed"
-// @router /worker/{workerId} [delete]
-func (m *workerModule) deleteWorkerHandler(c *gin.Context) {
+// @router /api/worker/{workerId} [delete]
+func (m workerModule) deleteWorkerHandler(c *gin.Context) {
 	workerID, ok := ginutil.RequireParamString(c, "workerId")
 	if !ok {
 		return

--- a/pkg/provisionerapi/worker.go
+++ b/pkg/provisionerapi/worker.go
@@ -88,6 +88,9 @@ func (m *workerModule) createWorkerHandler(c *gin.Context) {
 		ginutil.WriteInvalidBindError(c, err, "One or more parameters failed to parse when reading query parameters.")
 		return
 	}
+	if params.RunStages == "ALL" {
+		params.RunStages = ""
+	}
 	if params.RepoBranch == "" {
 		params.RepoBranch = params.GitBranch
 	}

--- a/pkg/provisionerapi/worker.go
+++ b/pkg/provisionerapi/worker.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/iver-wharf/wharf-cmd/pkg/provisioner"
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
+	"gopkg.in/yaml.v3"
 	"k8s.io/client-go/rest"
 )
 
@@ -33,6 +34,7 @@ func (m *workerModule) register(g *gin.RouterGroup) {
 // @summary List provisioned wharf-cmd-workers
 // @description Added in v0.8.0.
 // @tags worker
+// @produce json
 // @success 200 {object} []provisioner.Worker
 // @failure 500 {object} string "Failed"
 // @router /worker [get]
@@ -51,11 +53,74 @@ func (m *workerModule) listWorkersHandler(c *gin.Context) {
 // @summary Creates a new wharf-cmd-worker
 // @description Added in v0.8.0.
 // @tags worker
+// @produce json
+// @param BUILD_REF        query uint   true  "Build reference ID" example(123) minimum(0)
+// @param ENVIRONMENT      query string false "Which Wharf environment to use, as defined in the `.wharf-ci.yml` file."
+// @param GIT_BRANCH       query string false "Git branch" example(master)
+// @param GIT_FULLURL      query string true  "Full Git clone'able URL" example(ssh://git@github.com/iver-wharf/wharf-cmd.git)
+// @param GIT_TOKEN        query string false "Name of Git clone credentials secret"
+// @param REPO_BRANCH      query string false "Git branch" example(master)
+// @param REPO_GROUP       query string false "Repository group name" example(iver-wharf)
+// @param REPO_NAME        query string false "Repository name" example(wharf-cmd)
+// @param RUN_STAGES       query string false "Which stages to run" default(ALL) example(deploy)
+// @param VARS             query string false "Input variable values, as a JSON or YAML formatted map of variable names (as defined in the project's `.wharf-ci.yml` file) as keys paired with their string, boolean, or numeric value."
+// @param WHARF_INSTANCE   query string false "Wharf instance ID"
+// @param WHARF_PROJECT_ID query uint   false "Wharf project ID" minimum(0) example(456)
 // @success 201 {object} provisioner.Worker
 // @failure 500 {object} string "Failed"
 // @router /worker [post]
 func (m *workerModule) createWorkerHandler(c *gin.Context) {
-	worker, err := m.prov.CreateWorker(c.Request.Context())
+	var params = struct {
+		BuildRef       uint   `form:"BUILD_REF"`
+		Environment    string `form:"ENVIRONMENT"`
+		GitBranch      string `form:"GIT_BRANCH"`
+		GitFullURL     string `form:"GIT_FULLURL"`
+		GitToken       string `form:"GIT_TOKEN"`
+		RepoBranch     string `form:"REPO_BRANCH"`
+		RepoGroup      string `form:"REPO_GROUP"`
+		RepoName       string `form:"REPO_NAME"`
+		RunStages      string `form:"RUN_STAGES"`
+		Vars           string `form:"VARS"`
+		WharfInstance  string `form:"WHARF_INSTANCE"`
+		WharfProjectID uint   `form:"WHARF_PROJECT_ID"`
+	}{}
+	if err := c.ShouldBindQuery(params); err != nil {
+		ginutil.WriteInvalidBindError(c, err, "One or more parameters failed to parse when reading query parameters.")
+		return
+	}
+	if params.RepoBranch == "" {
+		params.RepoBranch = params.GitBranch
+	}
+	args := provisioner.WorkerArgs{
+		GitCloneBranch: params.GitBranch,
+		GitCloneURL:    params.GitFullURL,
+
+		Environment: params.Environment,
+		Stage:       params.RunStages,
+
+		WharfInstanceID: params.WharfInstance,
+		ProjectID:       params.WharfProjectID,
+		BuildID:         params.BuildRef,
+
+		AdditionalVars: map[string]any{
+			"BUILD_REF":   params.BuildRef,
+			"GIT_BRANCH":  params.RepoBranch,
+			"REPO_BRANCH": params.RepoBranch,
+			"REPO_GROUP":  params.RepoGroup,
+			"REPO_NAME":   params.RepoName,
+		},
+	}
+	if params.Vars != "" {
+		var inputVars map[string]any
+		if err := yaml.Unmarshal([]byte(params.Vars), &inputVars); err != nil {
+			ginutil.WriteInvalidParamError(c, err, "VARS",
+				"Failed to parse input variables. They should be a JSON or YAML formatted map of key-values.")
+			return
+		}
+		args.Inputs = inputVars
+	}
+
+	worker, err := m.prov.CreateWorker(c.Request.Context(), args)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, err)
 		return
@@ -69,6 +134,7 @@ func (m *workerModule) createWorkerHandler(c *gin.Context) {
 // @summary Deletes a wharf-cmd-worker
 // @description Added in v0.8.0.
 // @tags worker
+// @produce json
 // @param workerId path uint true "ID of worker to delete" minimum(0)
 // @success 204 "OK"
 // @failure 500 {object} string "Failed"

--- a/pkg/workerapi/workerserver/.gitignore
+++ b/pkg/workerapi/workerserver/.gitignore
@@ -1,3 +1,2 @@
 # Generated swaggo docs
-docs/docs.go
-docs/swagger.*
+docs/

--- a/pkg/workerapi/workerserver/artifact.go
+++ b/pkg/workerapi/workerserver/artifact.go
@@ -20,7 +20,7 @@ type ArtifactFileOpener interface {
 	OpenArtifactFile(artifactID uint) (io.ReadCloser, error)
 }
 
-func (m *artifactModule) register(g *gin.RouterGroup) {
+func (m artifactModule) register(g *gin.RouterGroup) {
 	g.GET("/artifact/:artifactId/download", m.downloadArtifactHandler)
 }
 
@@ -35,8 +35,8 @@ func (m *artifactModule) register(g *gin.RouterGroup) {
 // @failure 400 {object} problem.Response "Bad request"
 // @failure 404 {object} problem.Response "Cannot find artifact"
 // @failure 502 {object} problem.Response "Canont read artifact file"
-// @router /artifact/{artifactId}/download [post]
-func (m *artifactModule) downloadArtifactHandler(c *gin.Context) {
+// @router /api/artifact/{artifactId}/download [post]
+func (m artifactModule) downloadArtifactHandler(c *gin.Context) {
 	artifactID, ok := ginutil.ParseParamUint(c, "artifactId")
 	if !ok {
 		return

--- a/pkg/workerapi/workerserver/restserver.go
+++ b/pkg/workerapi/workerserver/restserver.go
@@ -5,12 +5,10 @@ import (
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
+	"github.com/iver-wharf/wharf-cmd/pkg/workerapi/workerserver/docs"
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 	ginSwagger "github.com/swaggo/gin-swagger"
 	"github.com/swaggo/gin-swagger/swaggerFiles"
-
-	// Load in swagger docs
-	_ "github.com/iver-wharf/wharf-cmd/pkg/workerapi/workerserver/docs"
 )
 
 type module interface {
@@ -45,7 +43,7 @@ func serveHTTP(s *restServer, listener net.Listener) error {
 
 	g := r.Group("/api")
 	g.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, func(c *ginSwagger.Config) {
-		c.InstanceName = "workerapi"
+		c.InstanceName = docs.SwaggerInfoworkerapi.InstanceName()
 	}))
 	g.GET("", pingHandler)
 

--- a/pkg/workerapi/workerserver/restserver.go
+++ b/pkg/workerapi/workerserver/restserver.go
@@ -44,7 +44,9 @@ func serveHTTP(s *restServer, listener net.Listener) error {
 	applyCORSConfig(r)
 
 	g := r.Group("/api")
-	g.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	g.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, func(c *ginSwagger.Config) {
+		c.InstanceName = "workerapi"
+	}))
 	g.GET("", pingHandler)
 
 	s.registerModules(g)


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added args to provisioner, that is added via:

  - query params to provisionerapi POST endpoint
  - flags to `wharf provisioner create`

- Extracted instance ID to a flag
- Extracted `provisioner.Provisioner` creation out from provisionerapi
- Added a bunch of small fixes to the Dockerfile
- Added .dockerignore to omit a lot of unused stuff from the Docker build, speeding up builds in the process.

- Removed `@basePath` as it's in the way more than helpful. It was messing up the swagger site because the endpoint was `/api` for ping and not `/api/`, but `@basePath` forced it to try `curl /api/`
- Moved ping endpoints to `GET /`

## Motivation

Some stuff missing, but I've created issues for them:

- Still doesn't handle Git credentials. But for now I've added all params provided by wharf-api: #118
- It doesn't populate any additional vars when running locally: #119

The `subdir` flag doesn't exist in wharf-api nor in our Jenkinsfiles, but I added it now because it was easy and aids in testing as we can do this:

```console
$ wharf provisioner create https://github.com/iver-wharf/wharf-cmd.git --subdir test/container
```

Closes #27
