### PR TITLE
Added non-git local vars to provisioned workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v0.8.0 (WIP)
 
-- Added provisioner commands: (#46, #59, #117)
+- Added provisioner commands: (#46, #59, #117, #121)
 
   - `wharf provisioner serve` that launches an HTTP REST api server with
     endpoints:


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Forwards OS env vars and .wharf-vars.yml files as `WHARF_VAR_` env vars to wharf-cmd-worker pods created via `wharf provisioner create`

## Motivation

Closes #119
