### PR TITLE
Fixed `wharf vars -i/-e` & `wharf aggregator --instance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added aggregator command `wharf aggregator serve` that looks for
   wharf-cmd-worker pods and pipes build results over to the wharf-api.
-  (#77, #126, #129)
+  (#77, #126, #129, #131)
 
 - Added new implementation for `wharf run`. (#33, #45, #66, #84, #107)
 
@@ -61,7 +61,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
     would be used in a `wharf run` invocation. (#93, #98, #102, #108, #110)
 
   - `wharf vars sub` that reads from STDIN or a file and performs variable
-    substitution, and then writes to STDOUT. (#110)
+    substitution, and then writes to STDOUT. (#110, #131)
 
 - Added support for `.gitignore` ignored files and directories when transferring
   repo in `wharf run`. Can be disabled via new `--no-gitignore` flag. (#85)

--- a/cmd/wharf/aggregator.go
+++ b/cmd/wharf/aggregator.go
@@ -41,6 +41,6 @@ kill endpoint.`,
 func init() {
 	rootCmd.AddCommand(aggregatorCmd)
 
-	provisionerCmd.Flags().StringVar(&provisionerFlags.instanceID, "instance", provisionerFlags.instanceID, "Wharf instance ID, used to avoid collisions in Pod ownership.")
+	aggregatorCmd.Flags().StringVar(&aggregatorFlags.instanceID, "instance", aggregatorFlags.instanceID, "Wharf instance ID, used to avoid collisions in Pod ownership.")
 	addKubernetesFlags(aggregatorCmd.PersistentFlags(), &aggregatorFlags.k8sOverrides)
 }

--- a/cmd/wharf/provisioner_create.go
+++ b/cmd/wharf/provisioner_create.go
@@ -81,7 +81,10 @@ func init() {
 
 	provisionerCreateCmd.Flags().StringVar(&provisionerCreateFlags.subdir, "subdir", "", "Subdirectory of repository where .wharf-ci.yml file is found.")
 
-	addWharfYmlStageFlag(provisionerCreateCmd, &provisionerCreateFlags.stage)
-	addWharfYmlEnvFlag(provisionerCreateCmd, &provisionerCreateFlags.env)
-	addWharfYmlInputsFlag(provisionerCreateCmd, &provisionerCreateFlags.inputs)
+	addWharfYmlStageFlag(provisionerCreateCmd, provisionerCreateCmd.Flags(),
+		&provisionerCreateFlags.stage)
+	addWharfYmlEnvFlag(provisionerCreateCmd, provisionerCreateCmd.Flags(),
+		&provisionerCreateFlags.env)
+	addWharfYmlInputsFlag(provisionerCreateCmd, provisionerCreateCmd.Flags(),
+		&provisionerCreateFlags.inputs)
 }

--- a/cmd/wharf/run.go
+++ b/cmd/wharf/run.go
@@ -164,8 +164,8 @@ func init() {
 	runCmd.Flags().BoolVar(&runFlags.serve, "serve", false, "Serves build results over REST & gRPC and waits until terminated (e.g via SIGTERM)")
 	runCmd.Flags().BoolVar(&runFlags.noGitIgnore, "no-gitignore", false, "Don't respect .gitignore files")
 
-	addWharfYmlStageFlag(runCmd, &runFlags.stage)
-	addWharfYmlEnvFlag(runCmd, &runFlags.env)
-	addWharfYmlInputsFlag(runCmd, &runFlags.inputs)
+	addWharfYmlStageFlag(runCmd, runCmd.Flags(), &runFlags.stage)
+	addWharfYmlEnvFlag(runCmd, runCmd.Flags(), &runFlags.env)
+	addWharfYmlInputsFlag(runCmd, runCmd.Flags(), &runFlags.inputs)
 	addKubernetesFlags(runCmd.Flags(), &runFlags.k8sOverrides)
 }

--- a/cmd/wharf/utils.go
+++ b/cmd/wharf/utils.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iver-wharf/wharf-cmd/pkg/varsub"
 	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"gopkg.in/typ.v4/slices"
 )
 
@@ -157,18 +158,18 @@ Sample file content:
 	}
 }
 
-func addWharfYmlStageFlag(cmd *cobra.Command, value *string) {
-	cmd.Flags().StringVarP(value, "stage", "s", "", "Stage to run (will run all stages if unset)")
+func addWharfYmlStageFlag(cmd *cobra.Command, flags *pflag.FlagSet, value *string) {
+	flags.StringVarP(value, "stage", "s", "", "Stage to run (will run all stages if unset)")
 	cmd.RegisterFlagCompletionFunc("stage", completeWharfYmlStage)
 }
 
-func addWharfYmlEnvFlag(cmd *cobra.Command, value *string) {
-	cmd.Flags().StringVarP(value, "environment", "e", "", "Environment selection")
+func addWharfYmlEnvFlag(cmd *cobra.Command, flags *pflag.FlagSet, value *string) {
+	flags.StringVarP(value, "environment", "e", "", "Environment selection")
 	cmd.RegisterFlagCompletionFunc("environment", completeWharfYmlEnv)
 }
 
-func addWharfYmlInputsFlag(cmd *cobra.Command, value *flagtypes.KeyValueArray) {
-	cmd.Flags().VarP(value, "input", "i", "Inputs (--input key=value), can be set multiple times")
+func addWharfYmlInputsFlag(cmd *cobra.Command, flags *pflag.FlagSet, value *flagtypes.KeyValueArray) {
+	flags.VarP(value, "input", "i", "Inputs (--input key=value), can be set multiple times")
 	cmd.RegisterFlagCompletionFunc("input", completeWharfYmlInputs)
 }
 

--- a/cmd/wharf/vars.go
+++ b/cmd/wharf/vars.go
@@ -6,9 +6,8 @@ import (
 )
 
 var varsFlags = struct {
-	env     string
-	showAll bool
-	inputs  flagtypes.KeyValueArray
+	env    string
+	inputs flagtypes.KeyValueArray
 }{}
 
 var varsCmd = &cobra.Command{
@@ -23,8 +22,6 @@ var varsCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(varsCmd)
 
-	varsCmd.PersistentFlags().BoolVarP(&varsFlags.showAll, "all", "a", false, "Show overridden variables")
-
-	addWharfYmlEnvFlag(varsCmd, &varsFlags.env)
-	addWharfYmlInputsFlag(varsCmd, &varsFlags.inputs)
+	addWharfYmlEnvFlag(varsCmd, varsCmd.PersistentFlags(), &varsFlags.env)
+	addWharfYmlInputsFlag(varsCmd, varsCmd.PersistentFlags(), &varsFlags.inputs)
 }

--- a/cmd/wharf/vars_list.go
+++ b/cmd/wharf/vars_list.go
@@ -21,6 +21,10 @@ var (
 	colorVarOverriddenNote = color.New(color.FgHiBlack, color.Italic)
 )
 
+var varsListFlags = struct {
+	showAll bool
+}{}
+
 var varsListCmd = &cobra.Command{
 	Use:     "list [path]",
 	Aliases: []string{"ls"},
@@ -101,7 +105,7 @@ environment variables, such as:
 			var longestKeyLength int
 			var notUsedCount int
 			for _, v := range vars {
-				if !varsFlags.showAll && !v.isUsed {
+				if !varsListFlags.showAll && !v.isUsed {
 					notUsedCount++
 					continue
 				}
@@ -118,7 +122,7 @@ environment variables, such as:
 
 			longestSpaces := strings.Repeat(" ", longestKeyLength+2)
 			for _, v := range vars {
-				if !varsFlags.showAll && !v.isUsed {
+				if !varsListFlags.showAll && !v.isUsed {
 					continue
 				}
 				spacesCount := longestKeyLength - utf8.RuneCountInString(v.Key) + 2
@@ -134,7 +138,7 @@ environment variables, such as:
 				}
 			}
 
-			if !varsFlags.showAll && notUsedCount > 0 {
+			if !varsListFlags.showAll && notUsedCount > 0 {
 				sb.WriteString("  ")
 				colorVarOverriddenNote.Fprintf(&sb, "(hiding %d overridden variables)\n", notUsedCount)
 			}
@@ -148,4 +152,6 @@ environment variables, such as:
 
 func init() {
 	varsCmd.AddCommand(varsListCmd)
+
+	varsListCmd.PersistentFlags().BoolVarP(&varsListFlags.showAll, "all", "a", false, "Show overridden variables")
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed -i & -e flags not persistent in wharf vars
- Fixed wrong --instance flag registration

## Motivation

Was unable to use `-e` in `wharf vars sub` :(
