### PR TITLE
Global --instance flag

### DIFF
--- a/cmd/wharf/aggregator.go
+++ b/cmd/wharf/aggregator.go
@@ -11,11 +11,7 @@ var aggregatorFlags = struct {
 
 	restConfig *rest.Config
 	namespace  string
-
-	instanceID string
-}{
-	instanceID: "local",
-}
+}{}
 
 var aggregatorCmd = &cobra.Command{
 	Use:   "aggregator",
@@ -41,6 +37,5 @@ kill endpoint.`,
 func init() {
 	rootCmd.AddCommand(aggregatorCmd)
 
-	aggregatorCmd.Flags().StringVar(&aggregatorFlags.instanceID, "instance", aggregatorFlags.instanceID, "Wharf instance ID, used to avoid collisions in Pod ownership.")
 	addKubernetesFlags(aggregatorCmd.PersistentFlags(), &aggregatorFlags.k8sOverrides)
 }

--- a/cmd/wharf/aggregator_serve.go
+++ b/cmd/wharf/aggregator_serve.go
@@ -12,7 +12,7 @@ var aggregatorServeCmd = &cobra.Command{
 the Wharf API through gRPC, killing the worker upon completion.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		k8sAggregator, err := aggregator.NewK8sAggregator(
-			aggregatorFlags.instanceID,
+			rootFlags.instanceID,
 			aggregatorFlags.namespace,
 			aggregatorFlags.restConfig,
 		)

--- a/cmd/wharf/provisioner.go
+++ b/cmd/wharf/provisioner.go
@@ -12,15 +12,11 @@ var provisionerFlags = struct {
 
 	restConfig *rest.Config
 	namespace  string
-
-	instanceID string
-}{
-	instanceID: "local",
-}
+}{}
 
 func newProvisioner() (provisioner.Provisioner, error) {
 	return provisioner.NewK8sProvisioner(
-		provisionerFlags.instanceID,
+		rootFlags.instanceID,
 		provisionerFlags.namespace,
 		provisionerFlags.restConfig)
 }
@@ -53,6 +49,5 @@ orchestration is handled inside the Kubernetes cluster, in comparison to the
 func init() {
 	rootCmd.AddCommand(provisionerCmd)
 
-	provisionerCmd.Flags().StringVar(&provisionerFlags.instanceID, "instance", provisionerFlags.instanceID, "Wharf instance ID, used to avoid collisions in Pod ownership.")
 	addKubernetesFlags(provisionerCmd.PersistentFlags(), &provisionerFlags.k8sOverrides)
 }

--- a/cmd/wharf/root.go
+++ b/cmd/wharf/root.go
@@ -30,9 +30,12 @@ const (
 var isLoggingInitialized bool
 
 var rootFlags = struct {
-	loglevel flagtypes.LogLevel
+	loglevel   flagtypes.LogLevel
+	instanceID string
 }{
 	loglevel: flagtypes.LogLevel(logger.LevelInfo),
+	// TODO: Make this configurable as well (wharf.instanceId, $WHARF_INSTANCEID)
+	instanceID: "local",
 }
 
 var rootCmd = &cobra.Command{
@@ -105,6 +108,7 @@ func init() {
 	rootCmd.InitDefaultVersionFlag()
 	rootCmd.PersistentFlags().VarP(&rootFlags.loglevel, "loglevel", "l", "Show debug information")
 	rootCmd.RegisterFlagCompletionFunc("loglevel", flagtypes.CompleteLogLevel)
+	rootCmd.PersistentFlags().StringVar(&rootFlags.instanceID, "instance", rootFlags.instanceID, "Wharf instance ID, used to avoid collisions in Pod ownership.")
 }
 
 func initLoggingIfNeeded() {

--- a/cmd/wharf/root.go
+++ b/cmd/wharf/root.go
@@ -28,7 +28,12 @@ const (
 )
 
 var isLoggingInitialized bool
-var loglevel flagtypes.LogLevel = flagtypes.LogLevel(logger.LevelInfo)
+
+var rootFlags = struct {
+	loglevel flagtypes.LogLevel
+}{
+	loglevel: flagtypes.LogLevel(logger.LevelInfo),
+}
 
 var rootCmd = &cobra.Command{
 	SilenceErrors: true,
@@ -98,7 +103,7 @@ func versionString(v app.Version) string {
 func init() {
 	cobra.OnInitialize(initLogging)
 	rootCmd.InitDefaultVersionFlag()
-	rootCmd.PersistentFlags().VarP(&loglevel, "loglevel", "l", "Show debug information")
+	rootCmd.PersistentFlags().VarP(&rootFlags.loglevel, "loglevel", "l", "Show debug information")
 	rootCmd.RegisterFlagCompletionFunc("loglevel", flagtypes.CompleteLogLevel)
 }
 
@@ -110,12 +115,12 @@ func initLoggingIfNeeded() {
 
 func initLogging() {
 	logConfig := consolepretty.DefaultConfig
-	if loglevel.Level() != logger.LevelDebug {
+	if rootFlags.loglevel.Level() != logger.LevelDebug {
 		logConfig.DisableCaller = true
 		logConfig.DisableDate = true
 		logConfig.ScopeMinLengthAuto = false
 	}
-	logger.AddOutput(loglevel.Level(), consolepretty.New(logConfig))
+	logger.AddOutput(rootFlags.loglevel.Level(), consolepretty.New(logConfig))
 	isLoggingInitialized = true
 }
 

--- a/pkg/provisioner/k8sprovisioner.go
+++ b/pkg/provisioner/k8sprovisioner.go
@@ -95,13 +95,14 @@ func (p k8sProvisioner) newWorkerPod(args WorkerArgs) v1.Pod {
 		repoVolumeMountPath = "/mnt/repo"
 		sshVolumeName       = "ssh"
 	)
+	workerInstanceID := typ.Coal(args.WharfInstanceID, p.instanceID)
 	labels := map[string]string{
 		"app":                          "wharf-cmd-worker",
 		"app.kubernetes.io/name":       "wharf-cmd-worker",
 		"app.kubernetes.io/part-of":    "wharf",
 		"app.kubernetes.io/managed-by": "wharf-cmd-provisioner",
 		"app.kubernetes.io/created-by": "wharf-cmd-provisioner",
-		"wharf.iver.com/instance":      typ.Coal(args.WharfInstanceID, p.instanceID),
+		"wharf.iver.com/instance":      workerInstanceID,
 		"wharf.iver.com/build-ref":     uitoa(args.BuildID),
 		"wharf.iver.com/project-id":    uitoa(args.ProjectID),
 	}
@@ -123,7 +124,12 @@ func (p k8sProvisioner) newWorkerPod(args WorkerArgs) v1.Pod {
 	}
 	gitArgs = append(gitArgs, repoVolumeMountPath)
 
-	wharfArgs := []string{"run", "--loglevel", "debug", "--serve"}
+	wharfArgs := []string{
+		"--loglevel", "debug",
+		"--instance", workerInstanceID,
+		"run",
+		"--serve",
+	}
 	if args.Environment != "" {
 		wharfArgs = append(wharfArgs, "--environment", args.Environment)
 	}


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added rootFlags
- Changed `--instance` to root flag
- Added so provisioner passes on `--instance` to worker

## Motivation

While all commands don't make use of it, it makes sense that all should be able to set it.
