### PR TITLE
Added user config dir support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,11 +114,14 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added ability to configure values, and wharf looks for it in multiple files in
   the following order, where former files take precedence over latter files on a
-  per-variable basis: (#116)
- 
+  per-variable basis: (#116, #134)
+
   - Environment variables, prefixed with `WHARF_`
   - File from environment variable: `WHARF_CONFIG`
   - File: `./wharf-cmd-config.yml`
+  - (Linux only) `~/.config/iver-wharf/wharf-cmd/wharf-cmd-config.yml`
+  - (Darwin/OS X only) `~/Library/Application Support/iver-wharf/wharf-cmd/wharf-cmd-config.yml`
+  - (Windows only) `%APPDATA%\iver-wharf\wharf-cmd\wharf-cmd-config.yml`
   - File: `/etc/iver-wharf/wharf-cmd/wharf-cmd-config.yml`
 
   Read more [here](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config).

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/iver-wharf/wharf-core/pkg/config"
@@ -267,11 +268,11 @@ var DefaultConfig = Config{
 // Config object.
 func LoadConfig() (Config, error) {
 	cfgBuilder := config.NewBuilder(DefaultConfig)
-	// TODO: Also add config file relative to home, e.g.:
-	//  ~/.config/iver-wharf/wharf-cmd/wharf-cmd-config.yml
-	//  $HOME/.config/iver-wharf/wharf-cmd/wharf-cmd-config.yml
-	// And OS-specific config paths.
+
 	cfgBuilder.AddConfigYAMLFile("/etc/iver-wharf/wharf-cmd/wharf-cmd-config.yml")
+	if confDir, err := os.UserConfigDir(); err == nil {
+		cfgBuilder.AddConfigYAMLFile(filepath.Join(confDir, "iver-wharf/wharf-cmd/wharf-cmd-config.yml"))
+	}
 	cfgBuilder.AddConfigYAMLFile(".wharf-cmd-config.yml")
 	if cfgFile, ok := os.LookupEnv("WHARF_CONFIG"); ok {
 		cfgBuilder.AddConfigYAMLFile(cfgFile)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,13 @@ import (
 //
 // 1. File: /etc/iver-wharf/wharf-cmd/wharf-cmd-config.yml
 //
+// 2. File: (config home)/iver-wharf/wharf-cmd/wharf-cmd-config.yml, depending
+// on OS:
+//
+//  - Linux:       ~/.config/iver-wharf/wharf-cmd/wharf-cmd-config.yml
+//  - Darwin/OS X: ~/Library/Application Support/iver-wharf/wharf-cmd/wharf-cmd-config.yml
+//  - Windows:     %APPDATA%\iver-wharf\wharf-cmd\wharf-cmd-config.yml
+//
 // 2. File: ./wharf-cmd-config.yml
 //
 // 3. File from environment variable: WHARF_CONFIG


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added `~/.config/iver-wharf/wharf-cmd/wharf-cmd-config.yml` support

## Motivation

Uses `os.UserConfigDir`, so it's automatically using `$XDG_CONFIG_HOME/...`, `%APPDATA%/...`, or `$HOME/Library/Application Support/...` depending on OS.

