### PR TITLE
staticcheck fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,10 +260,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   `resultstore`. (#71)
 
 - Added cancelling of builds via signals (once to shutdown with a grace period,
-  twice for a forceful shutdown): (#90, #104)
+  twice for a forceful shutdown): (#90, #104, #136)
 
   - `os.Interrupt`
-  - `os.Kill`
   - `syscall.SIGTERM`
   - `syscall.SIGHUP`
 

--- a/cmd/wharf/root.go
+++ b/cmd/wharf/root.go
@@ -170,6 +170,6 @@ func handleCancelSignals(cancel context.CancelFunc) {
 
 func newCancelSignalChan() <-chan os.Signal {
 	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, os.Interrupt, os.Kill, syscall.SIGTERM, syscall.SIGHUP)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
 	return ch
 }

--- a/cmd/wharf/run.go
+++ b/cmd/wharf/run.go
@@ -70,13 +70,11 @@ https://iver-wharf.github.io/#/usage-wharfyml/`,
 		store := resultstore.NewStore(resultstore.NewFS("./build_logs"))
 
 		go func() {
-			select {
-			case <-rootContext.Done():
-				if err := store.Close(); err != nil {
-					log.Warn().WithError(err).Message("Error closing store.")
-				} else {
-					log.Debug().Message("Successfully closed store.")
-				}
+			<-rootContext.Done()
+			if err := store.Close(); err != nil {
+				log.Warn().WithError(err).Message("Error closing store.")
+			} else {
+				log.Debug().Message("Successfully closed store.")
 			}
 		}()
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Remove untrappable os.Kill
- Remove excess select statement

## Motivation

```console
$ staticcheck ./...
cmd/wharf/root.go:173:34: os.Kill cannot be trapped (did you mean syscall.SIGTERM?) (SA1016)
cmd/wharf/run.go:73:4: should use a simple channel send/receive instead of select with a single case (S1000)
```

Apparently you can't trap a SIGKILL. My bad for suggesting it :P
