### PR TITLE
watchdog: Dont filter workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   See [docs/provisioner-git-ssh-secret.md](docs/provisioner-git-ssh-secret.md)
   for more info. (#120)
 
-- Added watchdog commands: (#62, #129)
+- Added watchdog commands: (#62, #129, #137)
 
   - `wharf watchdog serve` checks stray builds from the wharf-api and
     wharf-cmd-workers from the wharf-cmd-provisioner and kills them in an effort

--- a/pkg/watchdog/watchdog.go
+++ b/pkg/watchdog/watchdog.go
@@ -10,7 +10,6 @@ import (
 	"github.com/iver-wharf/wharf-cmd/pkg/config"
 	"github.com/iver-wharf/wharf-cmd/pkg/provisioner"
 	"github.com/iver-wharf/wharf-cmd/pkg/provisionerclient"
-	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 	"github.com/iver-wharf/wharf-core/pkg/logger"
 )
 
@@ -249,19 +248,5 @@ func (wd *watchdog) getRunningBuilds() ([]response.Build, error) {
 }
 
 func (wd *watchdog) getRunningWorkers() ([]provisioner.Worker, error) {
-	allWorkers, err := wd.prov.ListWorkers()
-	if err != nil {
-		return nil, err
-	}
-	var runningWorkers []provisioner.Worker
-	for _, w := range allWorkers {
-		switch w.Status {
-		case workermodel.StatusInitializing,
-			workermodel.StatusScheduling,
-			workermodel.StatusRunning,
-			workermodel.StatusNone:
-			allWorkers = append(allWorkers, w)
-		}
-	}
-	return runningWorkers, nil
+	return wd.prov.ListWorkers()
 }

--- a/pkg/watchdog/watchdog.go
+++ b/pkg/watchdog/watchdog.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iver-wharf/wharf-cmd/pkg/config"
 	"github.com/iver-wharf/wharf-cmd/pkg/provisioner"
 	"github.com/iver-wharf/wharf-cmd/pkg/provisionerclient"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 	"github.com/iver-wharf/wharf-core/pkg/logger"
 )
 
@@ -83,7 +84,7 @@ func (wd *watchdog) performCheck(now time.Time) (checkResult, error) {
 	if err != nil {
 		return checkResult{}, fmt.Errorf("get running builds from wharf-api: %w", err)
 	}
-	workers, err := wd.getRunningWorkers()
+	workers, err := wd.prov.ListWorkers()
 	if err != nil {
 		return checkResult{}, fmt.Errorf("get running workers from wharf-cmd-provisioner: %w", err)
 	}
@@ -157,7 +158,7 @@ func (wd *watchdog) killWorkers(workersToKill []provisioner.Worker) error {
 }
 
 func getBuildsToKill(builds []response.Build, workers []provisioner.Worker, safeAfter time.Time) []response.Build {
-	workersMap := mapWorkersOnID(workers)
+	workersMap := mapRunningWorkersOnID(workers)
 	var toKill []response.Build
 	for _, b := range builds {
 		reason := getReasonToNotKillBuild(b, workersMap, safeAfter)
@@ -224,10 +225,16 @@ func mapBuildsOnWorkerID(builds []response.Build) map[string]response.Build {
 	return m
 }
 
-func mapWorkersOnID(workers []provisioner.Worker) map[string]provisioner.Worker {
+func mapRunningWorkersOnID(workers []provisioner.Worker) map[string]provisioner.Worker {
 	m := make(map[string]provisioner.Worker, len(workers))
 	for _, w := range workers {
-		m[w.WorkerID] = w
+		switch w.Status {
+		case workermodel.StatusInitializing,
+			workermodel.StatusScheduling,
+			workermodel.StatusRunning,
+			workermodel.StatusNone:
+			m[w.WorkerID] = w
+		}
 	}
 	return m
 }
@@ -245,8 +252,4 @@ func (wd *watchdog) getRunningBuilds() ([]response.Build, error) {
 		return nil, err
 	}
 	return page.List, nil
-}
-
-func (wd *watchdog) getRunningWorkers() ([]provisioner.Worker, error) {
-	return wd.prov.ListWorkers()
 }

--- a/pkg/watchdog/watchdog_test.go
+++ b/pkg/watchdog/watchdog_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/iver-wharf/wharf-api-client-go/v2/pkg/model/response"
 	"github.com/iver-wharf/wharf-cmd/pkg/provisioner"
+	"github.com/iver-wharf/wharf-cmd/pkg/worker/workermodel"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/guregu/null.v4"
 )
@@ -38,8 +39,8 @@ func TestGetBuildsToKill(t *testing.T) {
 				{BuildID: 4, WorkerID: "jkl", ScheduledOn: null.TimeFrom(testTimeOld)},
 			},
 			workers: []provisioner.Worker{
-				{WorkerID: "abc"},
-				{WorkerID: "ghi"},
+				{WorkerID: "abc", Status: workermodel.StatusRunning},
+				{WorkerID: "ghi", Status: workermodel.StatusRunning},
 			},
 			want: []uint{2, 4},
 		},
@@ -52,7 +53,7 @@ func TestGetBuildsToKill(t *testing.T) {
 				{BuildID: 4, WorkerID: "jkl", ScheduledOn: null.TimeFrom(testTimeNow)},
 			},
 			workers: []provisioner.Worker{
-				{WorkerID: "abc"},
+				{WorkerID: "abc", Status: workermodel.StatusRunning},
 			},
 			want: []uint{3},
 		},


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Removed filtering of workers in wharf-cmd-watchdog

## Motivation

It was filtering on status, but in actuality we want it to kill ALL pods, no matter the status, as long as it's stray.

