### PR TITLE
Added git to Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added `--version`, `-v` flag to show the version of wharf-cmd. (#76)
 
+- Added Git to `quay.io/iver-wharf/wharf-cmd` Docker image. (#138)
+
 - Added dependencies:
 
   - `github.com/alta/protopatch` v0.5.0 (#51)

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN chmod +x scripts/update-version.sh  \
 
 ARG REG=docker.io
 FROM ${REG}/library/alpine:3.15 AS final
-RUN apk add --no-cache ca-certificates tzdata
+RUN apk add --no-cache ca-certificates tzdata git
 COPY --from=build /src/wharf /usr/local/bin/wharf
 ENTRYPOINT ["/usr/local/bin/wharf"]
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added `apk add git` to Dockerfile

## Motivation

wharf-cmd-worker uses Git to get some variables, such as tag, commit ID, etc.

This does increase the Docker image with ~9 MB, which isn't that great, but it's kind of required.

We could launch another image without that, or embed the [go-git](https://pkg.go.dev/github.com/go-git/go-git/v5) package, or getting the values from the `.git` directory surgically without using a `git` executable; all in the effort to make a smaller binary. But for now, this will do nicely.
