### PR TITLE
Skip logging timestamp in worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Changed to trim away everything before the last CR (carriage return)
   character in a log line from a Kubernetes pod. (#49)
 
+- Changed so `wharf run` logs the parsed log message provided by Kubernetes,
+  without the timestamp. (#148)
+
 - Changed location of packages and code files: (#44, #87)
 
   - File `pkg/core/utils/variablesreplacer.go` to its own package in `pkg/varsub`

--- a/pkg/resultstore/loglinewriter.go
+++ b/pkg/resultstore/loglinewriter.go
@@ -71,17 +71,16 @@ type logLineWriteCloser struct {
 	writeCloser io.WriteCloser
 }
 
-func (w *logLineWriteCloser) WriteLogLine(line string) error {
+func (w *logLineWriteCloser) WriteLogLine(line string) (LogLine, error) {
 	sanitized := sanitizeLogLine(line)
 	if _, err := w.writeCloser.Write([]byte(sanitized)); err != nil {
-		return err
+		return LogLine{}, err
 	}
 	if _, err := w.writeCloser.Write(newLineBytes); err != nil {
-		return err
+		return LogLine{}, err
 	}
 	logID := atomic.AddUint64(&w.lastLogID, 1)
-	w.store.parseAndPubLogLine(w.stepID, logID, sanitized)
-	return nil
+	return w.store.parseAndPubLogLine(w.stepID, logID, sanitized), nil
 }
 
 func (w *logLineWriteCloser) Close() error {

--- a/pkg/resultstore/loglinewriter_test.go
+++ b/pkg/resultstore/loglinewriter_test.go
@@ -17,9 +17,9 @@ func TestLogLineWriteCloser(t *testing.T) {
 		writeCloser: nopWriteCloser{&buf},
 		store:       &store{},
 	}
-	err := w.WriteLogLine(sampleTimeStr + " Foo bar")
+	_, err := w.WriteLogLine(sampleTimeStr + " Foo bar")
 	require.NoError(t, err, "write 1/2")
-	err = w.WriteLogLine(sampleTimeStr + " Moo doo")
+	_, err = w.WriteLogLine(sampleTimeStr + " Moo doo")
 	require.NoError(t, err, "write 2/2")
 
 	want := sampleTimeStr + " Foo bar\n" + sampleTimeStr + " Moo doo\n"
@@ -34,7 +34,7 @@ func TestLogLineWriteCloser_Sanitizes(t *testing.T) {
 		writeCloser: nopWriteCloser{&buf},
 		store:       &store{},
 	}
-	err := w.WriteLogLine(sampleTimeStr + " Foo \nbar")
+	_, err := w.WriteLogLine(sampleTimeStr + " Foo \nbar")
 	require.NoError(t, err)
 
 	want := sampleTimeStr + " Foo \\nbar\n"
@@ -116,7 +116,7 @@ func TestStore_OpenLogWriterUsesLastLogLineID(t *testing.T) {
 	require.NoError(t, err, "open writer")
 	assert.Equal(t, uint64(8), w.(*logLineWriteCloser).lastLogID)
 
-	err = w.WriteLogLine("Hello 9")
+	_, err = w.WriteLogLine("Hello 9")
 	require.NoError(t, err, "write line")
 	assert.Equal(t, uint64(9), w.(*logLineWriteCloser).lastLogID)
 }

--- a/pkg/resultstore/resultstore.go
+++ b/pkg/resultstore/resultstore.go
@@ -149,7 +149,7 @@ type LogLineWriteCloser interface {
 	// LogLine to any active subscriptions. An error is returned if it failed
 	// to write, such as if the file system has run out of disk space or if the
 	// file was removed.
-	WriteLogLine(line string) error
+	WriteLogLine(line string) (LogLine, error)
 }
 
 // LogLineReadCloser is the interface for reading log lines and ability to

--- a/pkg/worker/k8srunner.go
+++ b/pkg/worker/k8srunner.go
@@ -393,11 +393,13 @@ func (r k8sStepRunner) readLogs(ctx context.Context, opts *v1.PodLogOptions) err
 		if idx != -1 {
 			txt = txt[idx+1:]
 		}
-		r.log.Info().Message(txt)
 		if writer != nil {
-			if err := writer.WriteLogLine(txt); err != nil {
-				r.log.Error().WithError(err).Message("Failed to write log line.")
+			line, err := writer.WriteLogLine(txt)
+			if err != nil {
+				r.log.Error().WithError(err).Message("Failed to write log line. No further logs will be written.")
+				return err
 			}
+			r.log.Info().Message(line.Message)
 		}
 	}
 	return scanner.Err()


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed to log the parsed message instead of the raw log line in wharf-cmd-worker

## Motivation

Prettier logs. We already have the timestamp: it's NOW.

User can still get the timestamps by running with flag `--loglevel debug`
