### PR TITLE
Fixed varsub on more complex vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - `syscall.SIGTERM`
   - `syscall.SIGHUP`
 
+- Fixed variable substitution not recognizing kebab-cased variables.
+  Now all variable naming formats are supported inside the `${my-variable}`
+  syntax. (#154)
+
 ## v0.7.0 (scrapped)
 
 - Added parsing of `"environments"` fields in `.wharf-ci.yml` files. (!2)

--- a/pkg/varsub/varsub.go
+++ b/pkg/varsub/varsub.go
@@ -66,7 +66,7 @@ func substituteRec(value string, source Source, usedParams []string) (any, error
 				return nil, err
 			}
 		}
-		if len(matches) == 1 && len(value) == len(match.FullMatch) {
+		if len(matches) == 1 {
 			// keep the value as-is if it matches the whole value
 			return matchVal, nil
 		}

--- a/pkg/varsub/varsub.go
+++ b/pkg/varsub/varsub.go
@@ -58,7 +58,7 @@ func substituteRec(value string, source Source, usedParams []string) (any, error
 			continue
 		}
 
-		var matchVal = v.Value
+		matchVal := v.Value
 		if str, ok := matchVal.(string); ok && strings.Contains(str, "${") {
 			var err error
 			matchVal, err = substituteRec(str, source, append(usedParams, match.Name))

--- a/pkg/varsub/varsub.go
+++ b/pkg/varsub/varsub.go
@@ -21,6 +21,9 @@ type VarMatch struct {
 	Name string
 	// FullMatch is the entire match, including the variable syntax of ${}.
 	FullMatch string
+	// IsVar is true if this was a match on a variable, or false if it was
+	// just a match on the delimiting string
+	IsVar bool
 }
 
 var varSyntaxPattern = regexp.MustCompile(`\${\s*([^}]*)\s*}`)
@@ -32,23 +35,30 @@ func Substitute(value string, source Source) (any, error) {
 }
 
 func substituteRec(value string, source Source, usedParams []string) (any, error) {
-	result := value
-	matches := Matches(value)
+	matches := Split(value)
+	var sb strings.Builder
 	for _, match := range matches {
-		var matchVal any
+		if !match.IsVar {
+			sb.WriteString(match.FullMatch)
+			continue
+		}
+
 		if unescaped, ok := unescapeFullMatch(match.FullMatch); ok {
-			result = strings.Replace(result, match.FullMatch, unescaped, 1)
+			sb.WriteString(unescaped)
 			continue
 		}
 
 		if slices.Contains(usedParams, match.Name) {
 			return nil, ErrRecursiveLoop
 		}
+
 		v, ok := source.Lookup(match.Name)
 		if !ok {
+			sb.WriteString(match.FullMatch)
 			continue
 		}
-		matchVal = v.Value
+
+		var matchVal = v.Value
 		if str, ok := matchVal.(string); ok && strings.Contains(str, "${") {
 			var err error
 			matchVal, err = substituteRec(str, source, append(usedParams, match.Name))
@@ -61,9 +71,9 @@ func substituteRec(value string, source Source, usedParams []string) (any, error
 			return matchVal, nil
 		}
 		matchValStr := stringify(matchVal)
-		result = strings.Replace(result, match.FullMatch, matchValStr, 1)
+		sb.WriteString(matchValStr)
 	}
-	return result, nil
+	return sb.String(), nil
 }
 
 func unescapeFullMatch(fullMatch string) (string, bool) {
@@ -88,23 +98,31 @@ func stringify(val any) string {
 	}
 }
 
-// Matches returns all variable substitution-prone matches from a string.
-func Matches(value string) []VarMatch {
-	matches := varSyntaxPattern.FindAllStringSubmatch(value, -1)
-	var params []VarMatch
-
-	for _, match := range matches {
-		paramName := strings.TrimSpace(match[1])
-
-		if paramName == "" {
-			continue
+// Split up a string on its variable and non-variable matches.
+func Split(value string) []VarMatch {
+	matches := varSyntaxPattern.FindAllStringSubmatchIndex(value, -1)
+	if len(matches) == 0 {
+		return []VarMatch{{Name: "", FullMatch: value, IsVar: false}}
+	}
+	var vars []VarMatch
+	var lastEnd int
+	for _, m := range matches {
+		if m[0] > lastEnd {
+			vars = append(vars, VarMatch{
+				FullMatch: value[lastEnd:m[0]],
+			})
 		}
-
-		params = append(params, VarMatch{
-			Name:      paramName,
-			FullMatch: match[0],
+		vars = append(vars, VarMatch{
+			FullMatch: value[m[0]:m[1]],
+			Name:      strings.TrimSpace(value[m[2]:m[3]]),
+			IsVar:     true,
+		})
+		lastEnd = m[1]
+	}
+	if len(value) > lastEnd {
+		vars = append(vars, VarMatch{
+			FullMatch: value[lastEnd:],
 		})
 	}
-
-	return params
+	return vars
 }

--- a/pkg/varsub/varsub.go
+++ b/pkg/varsub/varsub.go
@@ -37,7 +37,8 @@ func substituteRec(value string, source Source, usedParams []string) (any, error
 	for _, match := range matches {
 		var matchVal any
 		if unescaped, ok := unescapeFullMatch(match.FullMatch); ok {
-			return strings.Replace(result, match.FullMatch, unescaped, 1), nil
+			result = strings.Replace(result, match.FullMatch, unescaped, 1)
+			continue
 		}
 
 		if slices.Contains(usedParams, match.Name) {

--- a/pkg/varsub/varsub_test.go
+++ b/pkg/varsub/varsub_test.go
@@ -157,6 +157,11 @@ func TestSubstitute(t *testing.T) {
 			want:  "Foo ${ %\n \r%\n} bar",
 		},
 		{
+			name:  "unescaped variables don't mess with substitution of matching vars after",
+			value: "Foo ${lorem} ${%lorem%} ${lorem}",
+			want:  "Foo ipsum ${lorem} ipsum",
+		},
+		{
 			name:  "simple text with invalid escaped text",
 			value: "Foo ${%lorem} bar",
 			want:  "Foo ${%lorem} bar",

--- a/pkg/varsub/varsub_test.go
+++ b/pkg/varsub/varsub_test.go
@@ -148,7 +148,7 @@ func TestSubstitute(t *testing.T) {
 		{
 			name:  "simple text with escaped empty white signs 2",
 			value: "Foo ${ %\n \r%\n} bar",
-			want:  "Foo ${\n \r} bar",
+			want:  "Foo ${ %\n \r%\n} bar",
 		},
 		{
 			name:  "simple text with invalid escaped text",

--- a/pkg/varsub/varsub_test.go
+++ b/pkg/varsub/varsub_test.go
@@ -98,7 +98,8 @@ func TestMatches(t *testing.T) {
 
 func TestSubstitute(t *testing.T) {
 	source := SourceMap{
-		"lorem": Val{Value: "ipsum"},
+		"lorem":   Val{Value: "ipsum"},
+		"foo-bar": Val{Value: "smilie"},
 	}
 	tests := []struct {
 		name  string
@@ -111,7 +112,7 @@ func TestSubstitute(t *testing.T) {
 			want:  "ipsum",
 		},
 		{
-			name:  "invalid simple variable",
+			name:  "undefined simple variable",
 			value: "${lorem ipsum}",
 			want:  "${lorem ipsum}",
 		},
@@ -119,6 +120,11 @@ func TestSubstitute(t *testing.T) {
 			name:  "simple text with variable",
 			value: "Foo ${lorem} bar",
 			want:  "Foo ipsum bar",
+		},
+		{
+			name:  "simple text with kebab variable",
+			value: "Foo ${foo-bar} bar",
+			want:  "Foo smilie bar",
 		},
 		{
 			name:  "simple text with variable and white spaces",

--- a/pkg/varsub/varsub_test.go
+++ b/pkg/varsub/varsub_test.go
@@ -7,95 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMatches(t *testing.T) {
-	tests := []struct {
-		name  string
-		value string
-		want  []VarMatch
-	}{
-		{
-			name:  "text without variable",
-			value: "text without variable",
-			want:  nil,
-		},
-		{
-			name:  "simple variable",
-			value: "${lorem}",
-			want:  []VarMatch{{Name: "lorem", FullMatch: "${lorem}"}},
-		},
-		{
-			name:  "invalid simple variable",
-			value: "${lorem ipsum}",
-			want:  []VarMatch{{Name: "lorem ipsum", FullMatch: "${lorem ipsum}"}},
-		},
-		{
-			name:  "simple text with variable",
-			value: "Foo ${lorem} bar",
-			want:  []VarMatch{{Name: "lorem", FullMatch: "${lorem}"}},
-		},
-		{
-			name:  "simple text with variable and white spaces",
-			value: "Foo ${\n \tlorem\r} bar",
-			want:  []VarMatch{{Name: "lorem", FullMatch: "${\n \tlorem\r}"}},
-		},
-		{
-			name:  "simple text with escaped variable",
-			value: "Foo ${%lorem%} bar",
-			want:  []VarMatch{{Name: "%lorem%", FullMatch: "${%lorem%}"}},
-		},
-		{
-			name:  "simple text with escaped empty string",
-			value: "Foo ${%%} bar",
-			want:  []VarMatch{{Name: "%%", FullMatch: "${%%}"}},
-		},
-		{
-			name:  "simple text with escaped empty string by singular percent",
-			value: "Foo ${%} bar",
-			want:  []VarMatch{{Name: "%", FullMatch: "${%}"}},
-		},
-		{
-			name:  "simple text with escaped white signs",
-			value: "Foo ${%\n \r%} bar",
-			want:  []VarMatch{{Name: "%\n \r%", FullMatch: "${%\n \r%}"}},
-		},
-		{
-			name:  "simple text with escaped white signs 2",
-			value: "Foo ${\t%\n \r% } bar",
-			want:  []VarMatch{{Name: "%\n \r%", FullMatch: "${\t%\n \r% }"}},
-		},
-		{
-			name:  "simple text with invalid escaped text",
-			value: "Foo ${%lorem} bar",
-			want:  []VarMatch{{Name: "%lorem", FullMatch: "${%lorem}"}},
-		},
-		{
-			name:  "simple text with invalid variable",
-			value: "Foo ${} bar",
-			want:  nil,
-		},
-		{
-			name:  "three variables",
-			value: "${lorem} ${ipsum} ${dolor}",
-			want: []VarMatch{
-				{Name: "lorem", FullMatch: "${lorem}"},
-				{Name: "ipsum", FullMatch: "${ipsum}"},
-				{Name: "dolor", FullMatch: "${dolor}"},
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := Matches(tc.value)
-			if len(tc.want) == 0 {
-				assert.Len(t, got, 0)
-				return
-			}
-			assert.Equal(t, tc.want, got)
-		})
-	}
-}
-
 func TestSubstitute(t *testing.T) {
 	source := SourceMap{
 		"lorem":   Val{Value: "ipsum"},
@@ -290,4 +201,58 @@ func TestSubstitute_errIfRecursiveLoop(t *testing.T) {
 	}
 	result, err := Substitute("root: ${lorem}", source)
 	assert.ErrorIsf(t, err, ErrRecursiveLoop, "unexpected result: %q", result)
+}
+
+func TestSplit(t *testing.T) {
+	var tests = []struct {
+		name      string
+		value     string
+		wantFull  []string
+		wantNames []string
+	}{
+		{
+			name:      "no matches",
+			value:     "hello there",
+			wantFull:  []string{"hello there"},
+			wantNames: []string{""},
+		},
+		{
+			name:      "many matches",
+			value:     "Foo ${lorem} ${%lorem%} ${lorem} bar",
+			wantFull:  []string{"Foo ", "${lorem}", " ", "${%lorem%}", " ", "${lorem}", " bar"},
+			wantNames: []string{"", "lorem", "", "%lorem%", "", "lorem", ""},
+		},
+		{
+			name:      "missing closing",
+			value:     "Foo ${lorem",
+			wantFull:  []string{"Foo ${lorem"},
+			wantNames: []string{""},
+		},
+		{
+			name:      "full string match",
+			value:     "${lorem}",
+			wantFull:  []string{"${lorem}"},
+			wantNames: []string{"lorem"},
+		},
+		{
+			name:      "matches next to each other",
+			value:     "${foo}${bar}",
+			wantFull:  []string{"${foo}", "${bar}"},
+			wantNames: []string{"foo", "bar"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotMatches := Split(tc.value)
+			var gotFull []string
+			var gotNames []string
+			for _, m := range gotMatches {
+				gotFull = append(gotFull, m.FullMatch)
+				gotNames = append(gotNames, m.Name)
+			}
+			assert.Equal(t, tc.wantFull, gotFull, ".FullMatch")
+			assert.Equal(t, tc.wantNames, gotNames, ".Name")
+		})
+	}
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed varsub to be less regex dependent
- Fixed varsub regex to allow dashes and other chars in variables
- Rewrote varsub to be more iterative, fixing edge cases.

## Motivation

The following did not work:

```yaml
image: ${my-variable}
```

Because the regex didn't account for dashes.

I changed to grab everything except the closing brace, to allow as complex variable names as possible.

Also, I fixed so `${   %foobar%   }` doesn't count as escaping. Only if the percent signs are just next to the braces do they count as escaping.
