### PR TITLE
Added configs for adding configs from provisioner to worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added ability to configure values, and wharf looks for it in multiple files in
   the following order, where former files take precedence over latter files on a
-  per-variable basis: (#116, #133, #134, #150)
+  per-variable basis: (#116, #133, #134, #150, #156)
 
   - Environment variables, prefixed with `WHARF_`
   - File from environment variable: `WHARF_CONFIG`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -143,6 +143,43 @@ type ProvisionerK8sWorkerConfig struct {
 	//
 	// Added in v0.8.0.
 	Container K8sContainerConfig
+	// ConfigMapName is the name of a Kubernetes ConfigMap to mount into the
+	// wharf-cmd-worker Pod. The ConfigMap can have the following keys, that
+	// corresponds to their respective files:
+	//
+	//  wharf-cmd-config.yml
+	//  wharf-vars.yml
+	//
+	// Sample ConfigMap manifest:
+	//
+	//  apiVersion: v1
+	//  kind: ConfigMap
+	//  metadata:
+	//    name: wharf-cmd-worker-config
+	//  data:
+	//    wharf-cmd-config.yml: |
+	//      instanceId: dev
+	//    wharf-vars.yml: |
+	//      vars:
+	//        REG_SECRET: docker-registry
+	//
+	// With the above manifest created in the same namespace as where the
+	// wharf-cmd-worker pods are created, you would then set this field to
+	//
+	//  wharf-cmd-worker-config
+	//
+	// Added in v0.8.0.
+	ConfigMapName string
+	// ExtraEnvs is an array of additional environment variables to set on the
+	// wharf-cmd-worker Pod.
+	//
+	// Added in v0.8.0.
+	ExtraEnvs []K8sEnvVar
+	// ExtraArgs is an array of additional command-line arguments to add to the
+	// wharf-cmd-worker Pod.
+	//
+	// Added in v0.8.0.
+	ExtraArgs []string
 }
 
 // K8sContainerConfig holds settings for a kubernetes container.

--- a/pkg/config/k8senv.go
+++ b/pkg/config/k8senv.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Taken from k8s.io/api@v0.23.3/core/v1/types.go
+
+package config
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// K8sEnvVar represents an environment variable present in a Container.
+type K8sEnvVar struct {
+	// Name of the environment variable. Must be a C_IDENTIFIER.
+	Name string
+
+	// Optional: no more than one of the following may be specified.
+
+	// Variable references $(VAR_NAME) are expanded
+	// using the previously defined environment variables in the container and
+	// any service environment variables. If a variable cannot be resolved,
+	// the reference in the input string will be unchanged. Double $$ are reduced
+	// to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+	// "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+	// Escaped references will never be expanded, regardless of whether the variable
+	// exists or not.
+	// Defaults to "".
+	Value string
+	// Source for the environment variable's value. Cannot be used if value is not empty.
+	ValueFrom *K8sEnvVarSource
+}
+
+// AsV1 returns the Kubernetes k8s.io/api/core/v1 type for this config.
+// An error is returned on any parse issues.
+func (e *K8sEnvVar) AsV1() (*v1.EnvVar, error) {
+	if e == nil {
+		return nil, nil
+	}
+	valueFrom, err := e.ValueFrom.AsV1()
+	if err != nil {
+		return nil, err
+	}
+	return &v1.EnvVar{
+		Name:      e.Name,
+		Value:     e.Value,
+		ValueFrom: valueFrom,
+	}, nil
+}
+
+// K8sEnvVarSource represents a source for the value of an EnvVar.
+type K8sEnvVarSource struct {
+	// Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+	// spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+	FieldRef *K8sObjectFieldSelector
+	// Selects a resource of the container: only resources limits and requests
+	// (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+	ResourceFieldRef *K8sResourceFieldSelector
+	// Selects a key of a ConfigMap.
+	ConfigMapKeyRef *K8sConfigMapKeySelector
+	// Selects a key of a secret in the pod's namespace
+	SecretKeyRef *K8sSecretKeySelector
+}
+
+// AsV1 returns the Kubernetes k8s.io/api/core/v1 type for this config.
+// An error is returned on any parse issues.
+func (e *K8sEnvVarSource) AsV1() (*v1.EnvVarSource, error) {
+	if e == nil {
+		return nil, nil
+	}
+	resourceFieldRef, err := e.ResourceFieldRef.AsV1()
+	if err != nil {
+		return nil, err
+	}
+	return &v1.EnvVarSource{
+		FieldRef:         e.FieldRef.AsV1(),
+		ResourceFieldRef: resourceFieldRef,
+		ConfigMapKeyRef:  e.ConfigMapKeyRef.AsV1(),
+		SecretKeyRef:     e.SecretKeyRef.AsV1(),
+	}, nil
+}
+
+// K8sObjectFieldSelector selects an APIVersioned field of an object.
+type K8sObjectFieldSelector struct {
+	// Version of the schema the FieldPath is written in terms of, defaults to "v1".
+	APIVersion string
+	// Path of the field to select in the specified API version.
+	FieldPath string
+}
+
+// AsV1 returns the Kubernetes k8s.io/api/core/v1 type for this config.
+func (e *K8sObjectFieldSelector) AsV1() *v1.ObjectFieldSelector {
+	if e == nil {
+		return nil
+	}
+	return &v1.ObjectFieldSelector{
+		APIVersion: e.APIVersion,
+		FieldPath:  e.FieldPath,
+	}
+}
+
+// K8sResourceFieldSelector represents container resources (cpu, memory) and their output format
+type K8sResourceFieldSelector struct {
+	// Container name: required for volumes, optional for env vars
+	ContainerName string
+	// Required: resource to select
+	Resource string
+	// Specifies the output format of the exposed resources, defaults to "1"
+	Divisor string
+}
+
+// AsV1 returns the Kubernetes k8s.io/api/core/v1 type for this config.
+// An error is returned on any parse issues.
+func (e *K8sResourceFieldSelector) AsV1() (*v1.ResourceFieldSelector, error) {
+	if e == nil {
+		return nil, nil
+	}
+	divisor, err := resource.ParseQuantity(e.Divisor)
+	if err != nil {
+		return nil, err
+	}
+	return &v1.ResourceFieldSelector{
+		ContainerName: e.ContainerName,
+		Resource:      e.ContainerName,
+		Divisor:       divisor,
+	}, nil
+}
+
+// K8sConfigMapKeySelector selects a key from a ConfigMap.
+type K8sConfigMapKeySelector struct {
+	// Name of the referent.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+	Name string
+	// The key to select.
+	Key string
+	// Specify whether the ConfigMap or its key must be defined
+	Optional *bool
+}
+
+// AsV1 returns the Kubernetes k8s.io/api/core/v1 type for this config.
+func (e *K8sConfigMapKeySelector) AsV1() *v1.ConfigMapKeySelector {
+	if e == nil {
+		return nil
+	}
+	return &v1.ConfigMapKeySelector{
+		LocalObjectReference: v1.LocalObjectReference{
+			Name: e.Name,
+		},
+		Key:      e.Key,
+		Optional: e.Optional,
+	}
+}
+
+// K8sSecretKeySelector selects a key of a Secret.
+type K8sSecretKeySelector struct {
+	// Name of the referent.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+	Name string
+	// The key of the secret to select from.  Must be a valid secret key.
+	Key string
+	// Specify whether the Secret or its key must be defined
+	Optional *bool
+}
+
+// AsV1 returns the Kubernetes k8s.io/api/core/v1 type for this config.
+func (e *K8sSecretKeySelector) AsV1() *v1.SecretKeySelector {
+	if e == nil {
+		return nil
+	}
+	return &v1.SecretKeySelector{
+		LocalObjectReference: v1.LocalObjectReference{
+			Name: e.Name,
+		},
+		Key:      e.Key,
+		Optional: e.Optional,
+	}
+}

--- a/pkg/config/k8senv.go
+++ b/pkg/config/k8senv.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Taken from k8s.io/api@v0.23.3/core/v1/types.go
+// Originally taken from k8s.io/api@v0.23.3/core/v1/types.go
+// This has since been modified to fit our use-case
 
 package config
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added configs, copied some from Kubernetes
- Use extraEnvs & extraArgs in provisioning
- Mount configmap if set

## Motivation

Closes #155
