### PR TITLE
Upgraded wharf-api-client-go to v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,7 +204,6 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - `github.com/gin-contrib/cors` v1.3.1 (#51)
   - `github.com/gin-gonic/gin` v1.7.1 (#46)
   - `github.com/golang/protobuf` v1.5.2 (#51)
-  - `github.com/iver-wharf/wharf-api-client-go/v2` v2.0.0 (#62)
   - `github.com/iver-wharf/wharf-core` (#2, #7)
   - `github.com/soheilhy/cmux` v0.1.4 (#51)
   - `github.com/spf13/pflag` v1.0.5 (#63)
@@ -226,7 +225,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Changed versions of numerous dependencies:
 
+  <!--lint ignore maximum-line-length-->
+
   - `github.com/gin-gonic/gin` from v1.7.1 to v1.7.7 (#59)
+  - `github.com/iver-wharf/wharf-api-client-go` from v1.2.0 to v2.2.1 (#62, #157)
   - `github.com/spf13/cobra` v1.1.3 to v1.3.0 (#64)
   - `github.com/stretchr/testify` v1.7.0 to v1.7.1 (#116)
   - `k8s.io/api` from v0.0.0 to v0.23.3 (#8)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.7.7
-	github.com/iver-wharf/wharf-api-client-go/v2 v2.0.1-0.20220303151222-6073acc9b23f
+	github.com/iver-wharf/wharf-api-client-go/v2 v2.2.1
 	github.com/iver-wharf/wharf-core v1.3.0
 	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/cobra v1.3.0
@@ -32,6 +32,7 @@ require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -407,8 +409,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iver-wharf/wharf-api-client-go/v2 v2.0.1-0.20220303151222-6073acc9b23f h1:gQlzl0d0WUQzTOgQ2wByt+ALZ8sLmqpHl3QZzBcrCOk=
-github.com/iver-wharf/wharf-api-client-go/v2 v2.0.1-0.20220303151222-6073acc9b23f/go.mod h1:LTwFb2GMvwfp0tMi1h0o9fGxXG9AoSoT6HFT0wQzzYk=
+github.com/iver-wharf/wharf-api-client-go/v2 v2.2.1 h1:B3dcq9uwy1SIAOVtL1EC5m2lFyY6RoaW6v1x9jhjLqg=
+github.com/iver-wharf/wharf-api-client-go/v2 v2.2.1/go.mod h1:yG3IiNQB+Uc28E0Y0wBNrPJxctznL7ppK3ApJOih77A=
 github.com/iver-wharf/wharf-core v1.3.0 h1:iJqa0JYBkMmJDkBKeErKCpZCa+qa97u5MLMBQ685Jhs=
 github.com/iver-wharf/wharf-core v1.3.0/go.mod h1:dpYtdL52i17Aue7An6mJL9dICeulBDsGZO/PxZYHgrE=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Upgraded wharf-api-client-go

## Motivation

Includes the fix for port requirement in wharfapi.Client.APIURL for gRPC communication

Issue: https://github.com/iver-wharf/wharf-api-client-go/issues/47
PR: https://github.com/iver-wharf/wharf-api-client-go/pull/48
