### PR TITLE
Replace REG_USER/REG_PASS with HELM_REG_SECRET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,25 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   Now all variable naming formats are supported inside the `${my-variable}`
   syntax. (#154)
 
+- Removed `REG_USER` and `REG_PASS` support in favor of `HELM_REG_SECRET`. This
+  is because the Wharf built-in variables should not contain any secrets by
+  themselves, but instead only refer to secrets, allowing their confidentiality
+  to be more easily maintained. (#162)
+
+- Added `HELM_REG_SECRET` for the `helm` and `helm-package` step types, which
+  functions the same way as `REG_SECRET` does for the `docker` step type. (#162)
+
+  The secret should contain a `config.json`, which can be created by running
+  `helm registry login` locally, and then creating a Kubernetes secret from
+  that:
+
+  ```sh
+  helm registry login harbor.example.com
+
+  kubectl create secret generic helm-registry \
+    --from-file=config.json=$HOME/.config/helm/registry/config.json
+  ```
+
 ## v0.7.0 (scrapped)
 
 - Added parsing of `"environments"` fields in `.wharf-ci.yml` files. (!2)

--- a/pkg/steps/k8sscript-helm-package.sh
+++ b/pkg/steps/k8sscript-helm-package.sh
@@ -12,8 +12,6 @@ set -euo pipefail
 : ${CHART_PATH:?"Missing required Helm chart path"}
 : ${CHART_VERSION?"Missing required Helm chart version"}
 : ${CHART_REPO:?"Missing required Helm registry URL"}
-: ${REG_USER:?"Missing required Helm registry username"}
-: ${REG_PASS:?"Missing required Helm registry password"}
 
 VERSION_FLAG=""
 
@@ -25,5 +23,5 @@ fi
 echo "\$ helm package $CHART_PATH $VERSION_FLAG"
 helm package "$CHART_PATH" "$VERSION_FLAG"
 
-echo "\$ helm push *.tgz $CHART_REPO --insecure --username *REDACTED* --password *REDACTED*"
-helm push *.tgz "$CHART_REPO" --insecure --username "$REG_USER" --password "$REG_PASS"
+echo "\$ helm push *.tgz $CHART_REPO --insecure"
+helm push *.tgz "$CHART_REPO" --insecure

--- a/pkg/wharfyml/parse_test.go
+++ b/pkg/wharfyml/parse_test.go
@@ -20,8 +20,6 @@ var testVarSource = varsub.SourceMap{
 	"REG_URL":    varsub.Val{Value: "http://harbor.example.com"},
 	"REG_SECRET": varsub.Val{Value: "docker-secret"},
 	"CHART_REPO": varsub.Val{Value: "http://charts.example.com"},
-	"REG_USER":   varsub.Val{Value: "admin"},
-	"REG_PASS":   varsub.Val{Value: "nimda"},
 }
 
 var testArgs = wharfyml.Args{


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Removed `REG_USER` & `REG_PASS` from `helm` & `helm-package` step types
- Added `HELM_REG_SECRET` to `helm` & `helm-package` step types

## Motivation

We don't want any secrets to be specified in the wharf-vars.yml file. It's better to always refer to other secrets.

This now works the same as the Docker step that uses a `REG_SECRET` variable.

Closes #160
