### PR TITLE
Added pkg.go.dev badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Wharf CI
 
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/2e59b0814f174cb2bebda4870797e15c)](https://www.codacy.com/gh/iver-wharf/wharf-cmd/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=iver-wharf/wharf-cmd&amp;utm_campaign=Badge_Grade)
+[![Go Reference](https://pkg.go.dev/badge/github.com/iver-wharf/wharf-cmd.svg)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd)
 
 A command-line interface to run tasks specified in a `.wharf-ci.yml` file.
 


### PR DESCRIPTION
## Summary

- Added badge using <https://pkg.go.dev/badge/?path=https%3A%2F%2Fpkg.go.dev%2Fgithub.com%2Fiver-wharf%2Fwharf-cmd>

## Motivation

Just a link to the generated documentation
