### PR TITLE
Added protolint

### DIFF
--- a/.protolint.yml
+++ b/.protolint.yml
@@ -1,0 +1,5 @@
+lint:
+  rules:
+    all_default: true
+    remove:
+      - FILE_HAS_COMMENT

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ deps-go:
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
 	go install github.com/alta/protopatch/cmd/protoc-gen-go-patch@v0.5.0
 	go install github.com/swaggo/swag/cmd/swag@v1.8.1
+	go install github.com/yoheimuta/protolint/cmd/protolint@v0.37.1
 
 .PHONY: deps-npm
 deps-npm:
@@ -52,7 +53,7 @@ check: swag
 .PHONY: proto
 proto: api/workerapi/v1/worker.pb.go
 
-api/workerapi/v1/worker.pb.go:
+api/workerapi/v1/worker.pb.go: api/workerapi/v1/worker.proto
 	protoc -I . \
 		-I `go list -m -f {{.Dir}} github.com/alta/protopatch` \
 		-I `go list -m -f {{.Dir}} google.golang.org/protobuf` \
@@ -110,10 +111,10 @@ pkg/workerapi/workerserver/docs:
 		--instanceName workerapi
 
 .PHONY: lint lint-fix \
-	lint-md lint-go \
-	lint-fix-md lint-fix-go
-lint: lint-md lint-go
-lint-fix: lint-fix-md lint-fix-go
+	lint-md lint-go lint-proto \
+	lint-fix-md lint-fix-go lint-fix-proto
+lint: lint-md lint-go lint-proto
+lint-fix: lint-fix-md lint-fix-go lint-fix-proto
 
 lint-md:
 	npx remark . .github
@@ -129,3 +130,9 @@ lint-go:
 lint-fix-go:
 	@echo goimports -d -w '**/*.go'
 	@goimports -d -w $(shell git ls-files "*.go")
+
+lint-proto:
+	protolint lint api/workerapi
+
+lint-fix-proto:
+	protolint lint -fix api/workerapi

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ make lint
 
 make lint-go # only lint Go code
 make lint-md # only lint Markdown files
+make lint-proto # only lint Protobuf (gRPC) files
 ```
 
 Some errors can be fixed automatically. Keep in mind that this updates the
@@ -63,6 +64,7 @@ make lint-fix
 
 make lint-fix-go # only lint and fix Go files
 make lint-fix-md # only lint and fix Markdown files
+make lint-fix-proto # only lint and fix Protobuf (gRPC) files
 ```
 
 ---

--- a/api/workerapi/v1/worker.pb.go
+++ b/api/workerapi/v1/worker.pb.go
@@ -25,17 +25,33 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Status is an enum of different statuses for the build steps.
 type Status int32
 
 const (
-	StatusUnspecified  Status = 0
-	StatusPending      Status = 1
-	StatusScheduling   Status = 2
+	// StatusUnspecified is the default value for this enum, and should be
+	// treated as an erroneous status.
+	StatusUnspecified Status = 0
+	// StatusPending means the build step is waiting to be scheduled, such as if
+	// it's build stage hasen't started yet due to the former build stage still
+	// running.
+	StatusPending Status = 1
+	// StatusScheduling means this build step has been scheduled, such as the
+	// Kubernetes Pod has been created, but the container has not yet started
+	// running. E.g if the Docker image is still being pulled.
+	StatusScheduling Status = 2
+	// StatusInitializing means the build step has started, but the initialization
+	// steps are not complete yet. E.g the repository is still being transferred.
 	StatusInitializing Status = 3
-	StatusRunning      Status = 4
-	StatusSuccess      Status = 5
-	StatusFailed       Status = 6
-	StatusCancelled    Status = 7
+	// StatusRunning means this build step is actively running.
+	StatusRunning Status = 4
+	// StatusSuccess means this build step has completed successfully.
+	StatusSuccess Status = 5
+	// StatusFailed means this build step has failed. E.g there was some
+	// user error in the build definition.
+	StatusFailed Status = 6
+	// StatusCancelled means this build was cancelled.
+	StatusCancelled Status = 7
 )
 
 // Enum value maps for Status.
@@ -206,6 +222,7 @@ func (*StreamArtifactEventsRequest) Descriptor() ([]byte, []int) {
 	return file_api_workerapi_v1_worker_proto_rawDescGZIP(), []int{2}
 }
 
+// StreamLogsResponse is a single log-line from a build step.
 type StreamLogsResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -285,6 +302,7 @@ func (x *StreamLogsResponse) GetMessage() string {
 	return ""
 }
 
+// StreamStatusEventsResponse is a single build step status update.
 type StreamStatusEventsResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -351,6 +369,7 @@ func (x *StreamStatusEventsResponse) GetStatus() Status {
 	return StatusUnspecified
 }
 
+// StreamArtifactEventsResponse is a single build artifact event.
 type StreamArtifactEventsResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/api/workerapi/v1/worker.proto
+++ b/api/workerapi/v1/worker.proto
@@ -11,13 +11,22 @@ option (go.lint).initialisms = "ID";
 
 option go_package = "github.com/iver-wharf/wharf-cmd/api/workerapi/v1";
 
+// Worker is the service for streaming build results from the wharf-cmd-worker.
 service Worker {
+  // StreamLogs opens a stream of all logs from the wharf-cmd-worker. The
+  // responses may be mixed between multiple build steps.
   rpc StreamLogs(StreamLogsRequest)
     returns (stream StreamLogsResponse);
 
+  // StreamStatusEvents opens a stream of all build status events. Every time
+  // a build step's status is changed, a new event is sent.
   rpc StreamStatusEvents(StreamStatusEventsRequest)
     returns (stream StreamStatusEventsResponse);
 
+  // StreamArtifactEvents opens a stream of all build artifact events. The
+  // actual artifact BLOB data cannot be accessed via this service, but must
+  // instead be downloaded via the HTTP REST API. This RPC should only be used
+  // to get a notification when a new artifact is available to download.
   rpc StreamArtifactEvents(StreamArtifactEventsRequest)
     returns (stream StreamArtifactEventsResponse);
 }
@@ -34,6 +43,7 @@ message StreamStatusEventsRequest {
 message StreamArtifactEventsRequest {
 }
 
+// StreamLogsResponse is a single log-line from a build step.
 message StreamLogsResponse {
   // LogID is the worker's own ID of the log line. It's unique per build step
   // for a given build, but may have collisions across multiple steps or builds.
@@ -49,6 +59,7 @@ message StreamLogsResponse {
   string message = 4;
 }
 
+// StreamStatusEventsResponse is a single build step status update.
 message StreamStatusEventsResponse {
   // EventID is the worker's own ID of the event the status.
   uint64 event_id = 1;
@@ -58,6 +69,7 @@ message StreamStatusEventsResponse {
   Status status = 3;
 }
 
+// StreamArtifactEventsResponse is a single build artifact event.
 message StreamArtifactEventsResponse {
   // ArtifactID is the worker's own ID of the artifact. It's unique per build
   // step for a given build, but may have collisions across multiple steps or
@@ -70,13 +82,29 @@ message StreamArtifactEventsResponse {
   string name = 3;
 }
 
+// Status is an enum of different statuses for the build steps.
 enum Status {
+  // StatusUnspecified is the default value for this enum, and should be
+  // treated as an erroneous status.
   STATUS_UNSPECIFIED = 0;
+  // StatusPending means the build step is waiting to be scheduled, such as if
+  // it's build stage hasen't started yet due to the former build stage still
+  // running.
   STATUS_PENDING = 1;
+  // StatusScheduling means this build step has been scheduled, such as the
+  // Kubernetes Pod has been created, but the container has not yet started
+  // running. E.g if the Docker image is still being pulled.
   STATUS_SCHEDULING = 2;
+  // StatusInitializing means the build step has started, but the initialization
+  // steps are not complete yet. E.g the repository is still being transferred.
   STATUS_INITIALIZING = 3;
+  // StatusRunning means this build step is actively running.
   STATUS_RUNNING = 4;
+  // StatusSuccess means this build step has completed successfully.
   STATUS_SUCCESS = 5;
+  // StatusFailed means this build step has failed. E.g there was some
+  // user error in the build definition.
   STATUS_FAILED = 6;
+  // StatusCancelled means this build was cancelled.
   STATUS_CANCELLED = 7;
 }

--- a/api/workerapi/v1/worker_grpc.pb.go
+++ b/api/workerapi/v1/worker_grpc.pb.go
@@ -19,8 +19,16 @@ const _ = grpc.SupportPackageIsVersion7
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type WorkerClient interface {
+	// StreamLogs opens a stream of all logs from the wharf-cmd-worker. The
+	// responses may be mixed between multiple build steps.
 	StreamLogs(ctx context.Context, in *StreamLogsRequest, opts ...grpc.CallOption) (Worker_StreamLogsClient, error)
+	// StreamStatusEvents opens a stream of all build status events. Every time
+	// a build step's status is changed, a new event is sent.
 	StreamStatusEvents(ctx context.Context, in *StreamStatusEventsRequest, opts ...grpc.CallOption) (Worker_StreamStatusEventsClient, error)
+	// StreamArtifactEvents opens a stream of all build artifact events. The
+	// actual artifact BLOB data cannot be accessed via this service, but must
+	// instead be downloaded via the HTTP REST API. This RPC should only be used
+	// to get a notification when a new artifact is available to download.
 	StreamArtifactEvents(ctx context.Context, in *StreamArtifactEventsRequest, opts ...grpc.CallOption) (Worker_StreamArtifactEventsClient, error)
 }
 
@@ -132,8 +140,16 @@ func (x *workerStreamArtifactEventsClient) Recv() (*StreamArtifactEventsResponse
 // All implementations must embed UnimplementedWorkerServer
 // for forward compatibility
 type WorkerServer interface {
+	// StreamLogs opens a stream of all logs from the wharf-cmd-worker. The
+	// responses may be mixed between multiple build steps.
 	StreamLogs(*StreamLogsRequest, Worker_StreamLogsServer) error
+	// StreamStatusEvents opens a stream of all build status events. Every time
+	// a build step's status is changed, a new event is sent.
 	StreamStatusEvents(*StreamStatusEventsRequest, Worker_StreamStatusEventsServer) error
+	// StreamArtifactEvents opens a stream of all build artifact events. The
+	// actual artifact BLOB data cannot be accessed via this service, but must
+	// instead be downloaded via the HTTP REST API. This RPC should only be used
+	// to get a notification when a new artifact is available to download.
 	StreamArtifactEvents(*StreamArtifactEventsRequest, Worker_StreamArtifactEventsServer) error
 	mustEmbedUnimplementedWorkerServer()
 }


### PR DESCRIPTION
## Summary

- Added install protolint to `make deps`
- Added `make lint-proto` & `make lint-fix-proto`
- Added comments to `.proto` file, describing all messages, services, and RPCs
- Changed `make proto` to only run if the generated file is older than the `.proto` file

## Motivation

Closes #16
