### PR TITLE
Added `wharf run --dry-run` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,15 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   # => [ "myVar": "bar" ]
   ```
 
+- Added `--dry-run` flag to `wharf run` command. The flag supports 3 different
+  values: (#170)
+
+  <!--lint ignore maximum-line-length-->
+
+  - `--dry-run none`: Disables dry-run. The build will be performed as usual
+  - `--dry-run client`: Only logs what would be run, without contacting Kubernetes
+  - `--dry-run server`: Submits server-side dry-run requests to Kubernetes
+
 - Added new implementation for `.wharf-ci.yml` file parsing that now supports
   returning multiple errors for the whole parsing as well as keep track of the
   line & column of each parse error. (#48, #58, #147, #153)

--- a/cmd/wharf/run.go
+++ b/cmd/wharf/run.go
@@ -23,7 +23,10 @@ var runFlags = struct {
 	serve       bool
 	noGitIgnore bool
 	inputs      flagtypes.KeyValueArray
-}{}
+	dryRun      flagtypes.DryRun
+}{
+	dryRun: flagtypes.DryRunNone,
+}
 
 var runCmd = &cobra.Command{
 	Use:   "run [path]",
@@ -95,6 +98,7 @@ https://iver-wharf.github.io/#/usage-wharfyml/`,
 				SkipGitIgnore: runFlags.noGitIgnore,
 				TarStore:      tarStore,
 				VarSource:     def.VarSource,
+				DryRun:        convDryRunFlag(runFlags.dryRun),
 			})
 		if err != nil {
 			return err
@@ -159,9 +163,22 @@ func init() {
 
 	runCmd.Flags().BoolVar(&runFlags.serve, "serve", false, "Serves build results over REST & gRPC and waits until terminated (e.g via SIGTERM)")
 	runCmd.Flags().BoolVar(&runFlags.noGitIgnore, "no-gitignore", false, "Don't respect .gitignore files")
+	runCmd.Flags().Var(&runFlags.dryRun, "dry-run", "Must be one of 'none', 'client', or 'server'")
+	runCmd.RegisterFlagCompletionFunc("dry-run", flagtypes.CompleteDryRun)
 
 	addWharfYmlStageFlag(runCmd, runCmd.Flags(), &runFlags.stage)
 	addWharfYmlEnvFlag(runCmd, runCmd.Flags(), &runFlags.env)
 	addWharfYmlInputsFlag(runCmd, runCmd.Flags(), &runFlags.inputs)
 	addKubernetesFlags(runCmd.Flags())
+}
+
+func convDryRunFlag(dryRun flagtypes.DryRun) worker.DryRun {
+	switch dryRun {
+	case flagtypes.DryRunClient:
+		return worker.DryRunClient
+	case flagtypes.DryRunServer:
+		return worker.DryRunServer
+	default:
+		return worker.DryRunNone
+	}
 }

--- a/cmd/wharf/run.go
+++ b/cmd/wharf/run.go
@@ -163,7 +163,7 @@ func init() {
 
 	runCmd.Flags().BoolVar(&runFlags.serve, "serve", false, "Serves build results over REST & gRPC and waits until terminated (e.g via SIGTERM)")
 	runCmd.Flags().BoolVar(&runFlags.noGitIgnore, "no-gitignore", false, "Don't respect .gitignore files")
-	runCmd.Flags().Var(&runFlags.dryRun, "dry-run", "Must be one of 'none', 'client', or 'server'")
+	runCmd.Flags().Var(&runFlags.dryRun, "dry-run", `Must be one of "none", "client", or "server"`)
 	runCmd.RegisterFlagCompletionFunc("dry-run", flagtypes.CompleteDryRun)
 
 	addWharfYmlStageFlag(runCmd, runCmd.Flags(), &runFlags.stage)

--- a/internal/flagtypes/dryrun.go
+++ b/internal/flagtypes/dryrun.go
@@ -2,6 +2,7 @@ package flagtypes
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -27,7 +28,7 @@ const (
 // Set implements the pflag.Value and fmt.Stringer interfaces.
 // This returns a human-readable representation of the loglevel.
 func (d *DryRun) String() string {
-	return string(*d)
+	return fmt.Sprintf(`"%s"`, string(*d))
 }
 
 // Set implements the pflag.Value interface.

--- a/internal/flagtypes/dryrun.go
+++ b/internal/flagtypes/dryrun.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// ensure they conform to the interfaces
+// ensure they conform to the interfaces.
 var dryRun = DryRunNone
 var _ pflag.Value = &dryRun
 
@@ -17,11 +17,11 @@ var _ pflag.Value = &dryRun
 type DryRun string
 
 const (
-	// DryRunNone disables dry-run. The build will be performed as usual
+	// DryRunNone disables dry-run. The build will be performed as usual.
 	DryRunNone DryRun = "none"
-	// DryRunClient only logs what would be run, without contacting Kubernetes
+	// DryRunClient only logs what would be run, without contacting Kubernetes.
 	DryRunClient DryRun = "client"
-	// DryRunServer submits server-side dry-run requests to Kubernetes
+	// DryRunServer submits server-side dry-run requests to Kubernetes.
 	DryRunServer DryRun = "server"
 )
 

--- a/internal/flagtypes/dryrun.go
+++ b/internal/flagtypes/dryrun.go
@@ -51,7 +51,7 @@ func parseDryRun(value string) (DryRun, error) {
 	case "server":
 		return DryRunServer, nil
 	default:
-		return "", errors.New("must be one of 'none', 'client', or 'server'")
+		return "", errors.New(`must be one of "none", "client", or "server"`)
 	}
 }
 

--- a/internal/flagtypes/dryrun.go
+++ b/internal/flagtypes/dryrun.go
@@ -1,0 +1,70 @@
+package flagtypes
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// ensure they conform to the interfaces
+var dryRun = DryRunNone
+var _ pflag.Value = &dryRun
+
+// DryRun is an enum flag for setting dry-run.
+type DryRun string
+
+const (
+	// DryRunNone disables dry-run. The build will be performed as usual
+	DryRunNone DryRun = "none"
+	// DryRunClient only logs what would be run, without contacting Kubernetes
+	DryRunClient DryRun = "client"
+	// DryRunServer submits server-side dry-run requests to Kubernetes
+	DryRunServer DryRun = "server"
+)
+
+// Set implements the pflag.Value and fmt.Stringer interfaces.
+// This returns a human-readable representation of the loglevel.
+func (d *DryRun) String() string {
+	return string(*d)
+}
+
+// Set implements the pflag.Value interface.
+// This parses the loglevel string and updates the loglevel variable.
+func (d *DryRun) Set(value string) error {
+	dryRun, err := parseDryRun(value)
+	if err != nil {
+		return err
+	}
+	*d = dryRun
+	return nil
+}
+
+func parseDryRun(value string) (DryRun, error) {
+	switch strings.ToLower(value) {
+	case "none":
+		return DryRunNone, nil
+	case "client":
+		return DryRunClient, nil
+	case "server":
+		return DryRunServer, nil
+	default:
+		return "", errors.New("must be one of 'none', 'client', or 'server'")
+	}
+}
+
+// Type implements the pflag.Value interface.
+// The value is only used in help text.
+func (d *DryRun) Type() string {
+	return "dry-run"
+}
+
+// CompleteDryRun returns completions for the DryRun type.
+func CompleteDryRun(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return []string{
+		string(DryRunNone) + "\tDisables dry-run. The build will be performed as usual",
+		string(DryRunClient) + "\tOnly logs what would be run, without contacting Kubernetes",
+		string(DryRunServer) + "\tSubmits server-side dry-run requests to Kubernetes",
+	}, cobra.ShellCompDirectiveNoFileComp
+}

--- a/internal/flagtypes/dryrun.go
+++ b/internal/flagtypes/dryrun.go
@@ -25,7 +25,7 @@ const (
 	DryRunServer DryRun = "server"
 )
 
-// Set implements the pflag.Value and fmt.Stringer interfaces.
+// String implements the pflag.Value and fmt.Stringer interfaces.
 // This returns a human-readable representation of the dry-run flag.
 func (d *DryRun) String() string {
 	return fmt.Sprintf(`"%s"`, string(*d))

--- a/internal/flagtypes/dryrun.go
+++ b/internal/flagtypes/dryrun.go
@@ -26,13 +26,13 @@ const (
 )
 
 // Set implements the pflag.Value and fmt.Stringer interfaces.
-// This returns a human-readable representation of the loglevel.
+// This returns a human-readable representation of the dry-run flag.
 func (d *DryRun) String() string {
 	return fmt.Sprintf(`"%s"`, string(*d))
 }
 
 // Set implements the pflag.Value interface.
-// This parses the loglevel string and updates the loglevel variable.
+// This parses the dry-run string and updates the dry-run variable.
 func (d *DryRun) Set(value string) error {
 	dryRun, err := parseDryRun(value)
 	if err != nil {

--- a/internal/flagtypes/loglevel.go
+++ b/internal/flagtypes/loglevel.go
@@ -36,7 +36,7 @@ func (l *LogLevel) String() string {
 	}
 }
 
-// Set implements the pflag.Value interface.
+// String implements the pflag.Value interface.
 // This parses the loglevel string and updates the loglevel variable.
 func (l *LogLevel) Set(val string) error {
 	newLevel, err := parseLevel(val)

--- a/internal/flagtypes/loglevel.go
+++ b/internal/flagtypes/loglevel.go
@@ -17,7 +17,7 @@ func (l LogLevel) Level() logger.Level {
 	return logger.Level(l)
 }
 
-// Set implements the pflag.Value and fmt.Stringer interfaces.
+// String implements the pflag.Value and fmt.Stringer interfaces.
 // This returns a human-readable representation of the loglevel.
 func (l *LogLevel) String() string {
 	switch l.Level() {
@@ -36,7 +36,7 @@ func (l *LogLevel) String() string {
 	}
 }
 
-// String implements the pflag.Value interface.
+// Set implements the pflag.Value interface.
 // This parses the loglevel string and updates the loglevel variable.
 func (l *LogLevel) Set(val string) error {
 	newLevel, err := parseLevel(val)

--- a/pkg/worker/k8srunner.go
+++ b/pkg/worker/k8srunner.go
@@ -38,15 +38,15 @@ var (
 	errIllegalParentDirAccess = errors.New("illegal parent directory access")
 )
 
-// DryRun is an enum of dry-run settings
+// DryRun is an enum of dry-run settings.
 type DryRun byte
 
 const (
-	// DryRunNone disables dry-run. The build will be performed as usual
+	// DryRunNone disables dry-run. The build will be performed as usual.
 	DryRunNone DryRun = iota
-	// DryRunClient only logs what would be run, without contacting Kubernetes
+	// DryRunClient only logs what would be run, without contacting Kubernetes.
 	DryRunClient
-	// DryRunServer submits server-side dry-run requests to Kubernetes
+	// DryRunServer submits server-side dry-run requests to Kubernetes.
 	DryRunServer
 )
 
@@ -138,7 +138,7 @@ func (f k8sStepRunnerFactory) NewStepRunner(
 	}
 	if r.DryRun != DryRunNone {
 		// We skip running dry-run here, as it will be run later in the actual
-		// step run. Otherwise it would dry-run twice
+		// step run. Otherwise it would dry-run twice.
 		if err := r.dryRunStep(ctx); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added `--dry-run` flag

## Motivation

It operates the same way as the `kubectl --dry-run` flag, where you specify either

- `--dry-run=none`
- `--dry-run=client`
- `--dry-run=server`

Closes #140
