### PR TITLE
Fixed environment filter bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added new implementation for `.wharf-ci.yml` file parsing that now supports
   returning multiple errors for the whole parsing as well as keep track of the
-  line & column of each parse error. (#48, #58, #147, #153)
+  line & column of each parse error. (#48, #58, #147, #153, #171)
 
 - Added support for a new file type: `.wharf-vars.yml`. It is used to define
   built-in variables, and wharf looks for it in multiple files in the

--- a/pkg/wharfyml/definition.go
+++ b/pkg/wharfyml/definition.go
@@ -137,16 +137,19 @@ func validateDefEnvironmentUsage(def Definition) errutil.Slice {
 func filterStagesOnEnv(stages []Stage, envFilter string) []Stage {
 	var filtered []Stage
 	for _, stage := range stages {
-		if containsEnvFilter(stage.Envs, envFilter) {
+		if stageShouldBeIncluded(stage.Envs, envFilter) {
 			filtered = append(filtered, stage)
 		}
 	}
 	return filtered
 }
 
-func containsEnvFilter(envRefs []EnvRef, envFilter string) bool {
-	if envFilter == "" && len(envRefs) == 0 {
+func stageShouldBeIncluded(envRefs []EnvRef, envFilter string) bool {
+	if len(envRefs) == 0 {
 		return true
+	}
+	if len(envRefs) > 0 && envFilter == "" {
+		return false
 	}
 	for _, ref := range envRefs {
 		if ref.Name == envFilter {

--- a/pkg/wharfyml/definition_test.go
+++ b/pkg/wharfyml/definition_test.go
@@ -1,0 +1,61 @@
+package wharfyml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterStagesOnEnv(t *testing.T) {
+	tests := []struct {
+		name      string
+		envFilter string
+		stages    []Stage
+		want      []string
+	}{
+		{
+			name:      "no filter skips all with env refs",
+			envFilter: "",
+			stages: []Stage{
+				{Name: "with-envs", Envs: []EnvRef{{Name: "env1"}}},
+				{Name: "with-empty-envs", Envs: []EnvRef{{Name: ""}}},
+				{Name: "no-envs", Envs: nil},
+			},
+			want: []string{"no-envs"},
+		},
+		{
+			name:      "with filter includes without env refs",
+			envFilter: "env1",
+			stages: []Stage{
+				{Name: "no-envs1", Envs: nil},
+				{Name: "no-envs2", Envs: nil},
+				{Name: "no-envs3", Envs: nil},
+			},
+			want: []string{"no-envs1", "no-envs2", "no-envs3"},
+		},
+		{
+			name:      "with filter only includes matching stages",
+			envFilter: "env1",
+			stages: []Stage{
+				{Name: "with-env1", Envs: []EnvRef{{Name: "env1"}}},
+				{Name: "with-env2", Envs: []EnvRef{{Name: "env2"}}},
+				{Name: "with-env1-and-env2", Envs: []EnvRef{
+					{Name: "env1"},
+					{Name: "env2"},
+				}},
+			},
+			want: []string{"with-env1", "with-env1-and-env2"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterStagesOnEnv(tc.stages, tc.envFilter)
+			var gotNames []string
+			for _, stage := range got {
+				gotNames = append(gotNames, stage.Name)
+			}
+			assert.Equal(t, tc.want, gotNames)
+		})
+	}
+}


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed bug where it skipped environment-less stages if environment was specified
- Added tests to prove it

## Motivation

It's always meant to run environment-less stages.

Closes #158