### PR TITLE
Save build results in /tmp via auto build ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added build result (logs, status updates) caching via file system. New
   package in `pkg/resultstore`. (#43, #69, #70)
 
+- Added so build results (logs, status updates) are stored in
+  `/tmp/wharf-cmd-build-00123-xxxxxxx` directory using a unique generated
+  build ID, or using the build ID provided by the `--build-id` flag on
+  the `wharf run` command. (#172)
+
 - Added all kubeconfig-related flags from `kubectl` but with a `--k8s-*` prefix.
   This allows e.g Wharf to run as a service account via the `--k8s-as` flag,
   among other things. (#63)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - `github.com/gin-gonic/gin` v1.7.1 (#46)
   - `github.com/golang/protobuf` v1.5.2 (#51)
   - `github.com/iver-wharf/wharf-core` (#2, #7)
+  - `github.com/rogpeppe/go-internal` v1.8.1 (#172)
   - `github.com/soheilhy/cmux` v0.1.4 (#51)
   - `github.com/spf13/pflag` v1.0.5 (#63)
   - `github.com/swaggo/gin-swagger` v1.4.1 (#59)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gin-gonic/gin v1.7.7
 	github.com/iver-wharf/wharf-api-client-go/v2 v2.2.1
 	github.com/iver-wharf/wharf-core v1.3.0
+	github.com/rogpeppe/go-internal v1.8.1
 	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -651,8 +651,9 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=

--- a/internal/lastbuild/lastbuild.go
+++ b/internal/lastbuild/lastbuild.go
@@ -1,0 +1,92 @@
+package lastbuild
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/rogpeppe/go-internal/lockedfile"
+)
+
+// Next returns the next build ID to use. It calculates this by locking the
+// build ID file, reading its current value, bumping it by +1, then writing
+// the new value, and then releasing the file lock.
+func Next() (uint, error) {
+	file, err := editFile()
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	last, err := readLast(file)
+	if err != nil {
+		return 0, err
+	}
+	next := last + 1
+
+	file.Seek(0, io.SeekStart)
+	err = writeNext(file, next)
+	if err != nil {
+		return 0, err
+	}
+
+	return next, nil
+}
+
+func editFile() (*lockedfile.File, error) {
+	path, err := Path()
+	if err != nil {
+		return nil, err
+	}
+	file, err := lockedfile.Edit(path)
+	if os.IsNotExist(err) {
+		return createFile(path)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+func createFile(path string) (*lockedfile.File, error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0775); err != nil {
+		return nil, err
+	}
+	return lockedfile.Create(path)
+}
+
+func readLast(reader io.Reader) (uint, error) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Scan()
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+	s := strings.TrimSpace(scanner.Text())
+	if s == "" {
+		return 0, nil
+	}
+	i64, err := strconv.ParseUint(s, 10, 0)
+	if err != nil {
+		return 0, err
+	}
+	return uint(i64), nil
+}
+
+func writeNext(writer io.Writer, next uint) error {
+	_, err := fmt.Fprintln(writer, next)
+	return err
+}
+
+// Path returns the path to the file that contains the last build ID.
+func Path() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", nil
+	}
+	return filepath.Join(cacheDir, "iver-wharf", "wharf-cmd", "last-build-id.txt"), nil
+}

--- a/pkg/provisioner/k8sprovisioner.go
+++ b/pkg/provisioner/k8sprovisioner.go
@@ -186,6 +186,7 @@ func (p k8sProvisioner) newWorkerPod(args WorkerArgs) v1.Pod {
 		"--instance", workerInstanceID,
 		"run",
 		"--serve",
+		"--build-id", uitoa(args.BuildID),
 	}
 	if args.Environment != "" {
 		wharfArgs = append(wharfArgs, "--environment", args.Environment)

--- a/pkg/resultstore/fs.go
+++ b/pkg/resultstore/fs.go
@@ -10,6 +10,9 @@ import (
 // FS is a filesystem with ability to open files in either append-only,
 // write-only, or read only mode.
 type FS interface {
+	// Path returns the root directory of this FS. This is only used in logging,
+	// and may return any helpful information.
+	Path() string
 	// OpenAppend creates or opens a file in append-only mode, meaning all written
 	// data is appended to the end.
 	OpenAppend(name string) (io.WriteCloser, error)
@@ -33,6 +36,10 @@ func NewFS(dir string) FS {
 
 type osFS struct {
 	dir string
+}
+
+func (fs osFS) Path() string {
+	return fs.dir
 }
 
 func (fs osFS) OpenAppend(name string) (io.WriteCloser, error) {

--- a/pkg/resultstore/fs_test.go
+++ b/pkg/resultstore/fs_test.go
@@ -29,6 +29,10 @@ type mockFS struct {
 	listDirEntries func(name string) ([]fs.DirEntry, error)
 }
 
+func (fs mockFS) Path() string {
+	return "mock-fs"
+}
+
 func (fs mockFS) OpenAppend(name string) (io.WriteCloser, error) {
 	return fs.openAppend(name)
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added internal/lastbuild to calculate next build ID
- Added `--build-id` flag to `wharf run`
- Changed so provisioner forwards the build ID

## Motivation

The temporary directory is cleaned automatically after a few days on Linux and after each reboot. Don't know how Windows works, but I'd imagine something similar.

This makes it a much better place for build results to be stored, instead of at `./build_logs`

It doesn't populate the `BUILD_REF` variable yet, nor sets the K8s Pod annotations where needed. But it's a start.

## Preview

```console
$ wharf run test/container
[INFO |TARSTORE] Copying files.  src=/home/kalle/dev/wharf/wharf-cmd/test/container  dst=/tmp/wharf-cmd-repo-1888293141/full
[INFO |TARSTORE] Creating tarball.  path=/tmp/wharf-cmd-repo-1888293141/full.tar
[INFO ] Starting build.  buildId=3
[INFO ] Starting stage.  stages=0/1  stage=test
[INFO ] Starting step.  steps=0/2  stage=test  step=step2
[INFO ] Starting step.  steps=0/2  stage=test  step=step1
[INFO |test/step1] Hello world!
[INFO |test/step1] output from somefile.txt:
[INFO |test/step1] Hello from somefile.txt
[INFO ] Done with step.  steps=1/2  stage=test  step=step1  dur=10s
[INFO |test/step2] Wed May 18 08:59:35 UTC 2022
[INFO ] Done with step.  steps=2/2  stage=test  step=step2  dur=11s
[INFO ] Done with stage.  stages=1/1  stage=test  dur=11s
[INFO ] Done with build.
	
	Build results are available at:
	  /tmp/wharf-cmd-build-00003-3552906965
	
	  dur=11s  status=Success
```

It's also getting printed when cancelling a build:

```console
$ wharf run test/container
[INFO |TARSTORE] Copying files.  src=/home/kalle/dev/wharf/wharf-cmd/test/container  dst=/tmp/wharf-cmd-repo-1958037044/full
[INFO |TARSTORE] Creating tarball.  path=/tmp/wharf-cmd-repo-1958037044/full.tar
[INFO ] Starting build.  buildId=4
[INFO ] Starting stage.  stages=0/1  stage=test
[INFO ] Starting step.  steps=0/2  stage=test  step=step2
[INFO ] Starting step.  steps=0/2  stage=test  step=step1
^C[INFO ] Cancelling build. Press ^C again to force quit.  gracePeriod=10s
[INFO ] Cancelled pod.  steps=1/2  stage=test  step=step1  dur=0s
[INFO ] Cancelled pod.  steps=2/2  stage=test  step=step2  dur=0s
[WARN ] Failed stage. Skipping any further stages.  stages=1/1  stage=test  dur=0s  status=Failed  failed=``  cancelled=step1,step2
[INFO ] Done with build.
	
	Build results are available at:
	  /tmp/wharf-cmd-build-00004-3997051063
	
	  dur=0s  status=Cancelled
```
