### PR TITLE
Fixed file stores not closing on force quit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,11 +142,15 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added variable substitution support for referenced files in `kubectl` and
   `helm` step types. (#89)
 
-- Added file transfer cache, stored in `/tmp/wharf-cmd-repo-xxxxx/full.tar`,
-  that is reused by all steps in a single build. (#89)
-
 - Added build result (logs, status updates) caching via file system. New
   package in `pkg/resultstore`. (#43, #69, #70)
+
+- Added file transfer cache, stored in `/tmp/wharf-cmd-repo-xxxxx/full.tar`,
+  that is reused by all steps in a single build.
+  New package in `pkg/tarstore` (#89)
+
+- Fixed `pkg/resultstore` and `pkg/tarstore` not cleaning up on wharf-triggered
+  force exits, such as on timeout waiting for pods to terminate. (#176)
 
 - Added so build results (logs, status updates) are stored in
   `/tmp/wharf-cmd-build-00123-xxxxxxx` directory using a unique generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,12 +142,12 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added variable substitution support for referenced files in `kubectl` and
   `helm` step types. (#89)
 
-- Added build result (logs, status updates) caching via file system. New
-  package in `pkg/resultstore`. (#43, #69, #70)
-
 - Added file transfer cache, stored in `/tmp/wharf-cmd-repo-xxxxx/full.tar`,
   that is reused by all steps in a single build.
   New package in `pkg/tarstore` (#89)
+
+- Added build result (logs, status updates) caching via file system. New
+  package in `pkg/resultstore`. (#43, #69, #70)
 
 - Fixed `pkg/resultstore` and `pkg/tarstore` not cleaning up on wharf-triggered
   force exits, such as on timeout waiting for pods to terminate. (#176)

--- a/cmd/wharf/run.go
+++ b/cmd/wharf/run.go
@@ -79,23 +79,18 @@ https://iver-wharf.github.io/#/usage-wharfyml/`,
 		if err != nil {
 			return err
 		}
+		defer store.Close()
+		closeBeforeForceQuit(store)
 		log.Debug().WithString("path", store.Path()).
 			Message("Created result store.")
-
-		go func() {
-			<-rootContext.Done()
-			if err := store.Close(); err != nil {
-				log.Warn().WithError(err).Message("Error closing store.")
-			} else {
-				log.Debug().Message("Successfully closed store.")
-			}
-		}()
 
 		tarStore, err := tarstore.New(currentDir)
 		if err != nil {
 			return err
 		}
 		defer tarStore.Close()
+		closeBeforeForceQuit(tarStore)
+
 		b, err := worker.NewK8s(rootContext, def,
 			worker.K8sRunnerOptions{
 				BuildOptions: worker.BuildOptions{


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added extra `io.Closer.Close()` calls on force quit

## Motivation

The resultstore and tarstore sometimes didn't clean themselves up.

Don't know how much of a dirty hack this is, or if it's a good convention.

Not everything is added to this "pre-force-exit" hook, but instead only the file persistence stuff
