### PR TITLE
Fixed varsub recursively on fmt.Stringer's

### DIFF
--- a/pkg/varsub/varsub.go
+++ b/pkg/varsub/varsub.go
@@ -58,8 +58,12 @@ func substituteRec(value string, source Source, usedParams []string) (any, error
 			continue
 		}
 
+		if strings.Contains(match.Name, "spark-version") {
+			fmt.Printf("## Looking up spark-version: %q => %q\n", match.FullMatch, v)
+		}
+
 		matchVal := v.Value
-		if str, ok := matchVal.(string); ok && strings.Contains(str, "${") {
+		if str, ok := asString(matchVal); ok && strings.Contains(str, "${") {
 			var err error
 			matchVal, err = substituteRec(str, source, append(usedParams, match.Name))
 			if err != nil {
@@ -74,6 +78,17 @@ func substituteRec(value string, source Source, usedParams []string) (any, error
 		sb.WriteString(matchValStr)
 	}
 	return sb.String(), nil
+}
+
+func asString(v any) (string, bool) {
+	switch v := v.(type) {
+	case string:
+		return v, true
+	case fmt.Stringer:
+		return v.String(), true
+	default:
+		return "", false
+	}
 }
 
 func unescapeFullMatch(fullMatch string) (string, bool) {

--- a/pkg/varsub/varsub_test.go
+++ b/pkg/varsub/varsub_test.go
@@ -176,6 +176,15 @@ func TestSubstitute_recursive(t *testing.T) {
 			want:  "001122221100",
 		},
 		{
+			name: "stringer",
+			source: SourceMap{
+				"one": Val{Value: testStringer{str: "11${two}11"}},
+				"two": Val{Value: testStringer{"2222"}},
+			},
+			value: "00${one}00",
+			want:  "001122221100",
+		},
+		{
 			name: "typed",
 			source: SourceMap{
 				"one": Val{Value: "${two}"},
@@ -193,6 +202,14 @@ func TestSubstitute_recursive(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+type testStringer struct {
+	str string
+}
+
+func (t testStringer) String() string {
+	return t.str
 }
 
 func TestSubstitute_errIfRecursiveLoop(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixed using recursive varsub in environment variables and input variables

## Motivation

The `visit.VarSubNode` was used when the variable source came from a node, such as:

```yaml
# .wharf-ci.yml

environments:
  my-env:
    my-env-var: hello-${GIT_SAFEBRANCH}

my-stage:
  my-step:
    docker:
      tag: ${my-env-var}
```

The above previously resolved to:

```yaml
my-stage:
  my-step:
    docker:
      tag: hello-${GIT_SAFEBRANCH}
```

While it should've resolved to:

```yaml
my-stage:
  my-step:
    docker:
      tag: hello-master
```

This was because when substituting using the environment variables or input defaults, their type is not `string` but instead `visit.VarSubNode`
