### PR TITLE
Added help command `wharf vars yml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - `wharf vars sub` that reads from STDIN or a file and performs variable
     substitution, and then writes to STDOUT. (#110, #131)
 
+  - `wharf vars yml` that prints the parsed `.wharf-ci.yml` file to STDOUT,
+    with all variables substituted. (#179)
+
 - Added support for `.gitignore` ignored files and directories when transferring
   repo in `wharf run`. Can be disabled via new `--no-gitignore` flag. (#85)
 

--- a/cmd/wharf/vars_yml.go
+++ b/cmd/wharf/vars_yml.go
@@ -3,10 +3,8 @@ package main
 import (
 	"os"
 
-	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml"
 	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml/visit"
 	"github.com/spf13/cobra"
-	"gopkg.in/typ.v4/slices"
 	"gopkg.in/yaml.v3"
 )
 
@@ -26,16 +24,7 @@ how it would be used if all values were inlined.`,
 		return []string{"yml"}, cobra.ShellCompDirectiveFilterFileExt
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		currentDir, err := parseCurrentDir(slices.SafeGet(args, 0))
-		if err != nil {
-			return err
-		}
-
-		def, err := parseBuildDefinition(currentDir, wharfyml.Args{
-			Env:                varsFlags.env,
-			Inputs:             parseInputArgs(varsFlags.inputs),
-			SkipStageFiltering: varsYMLFlags.showAll,
-		})
+		def, err := varsCmdParseBuildDef(args)
 		if err != nil {
 			return err
 		}

--- a/cmd/wharf/vars_yml.go
+++ b/cmd/wharf/vars_yml.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+
+	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml"
+	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml/visit"
+	"github.com/spf13/cobra"
+	"gopkg.in/typ.v4/slices"
+	"gopkg.in/yaml.v3"
+)
+
+var varsYMLFlags = struct {
+	stage string
+}{}
+
+var varsYMLCmd = &cobra.Command{
+	Use:     "yml [path]",
+	Aliases: []string{"yaml"},
+	Short:   "Print the parsed .wharf-ci.yml file",
+	Long: `Parses a .wharf-ci.yml file and prints the parsed definition
+how it would be used if all values were inlined.`,
+	Args: cobra.MaximumNArgs(1),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"yml"}, cobra.ShellCompDirectiveFilterFileExt
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		currentDir, err := parseCurrentDir(slices.SafeGet(args, 0))
+		if err != nil {
+			return err
+		}
+
+		def, err := parseBuildDefinition(currentDir, wharfyml.Args{
+			Env:    varsFlags.env,
+			Inputs: parseInputArgs(varsFlags.inputs),
+		})
+		if err != nil {
+			return err
+		}
+
+		writer := os.Stdout
+		for _, stage := range def.Stages {
+			enc := yaml.NewEncoder(writer)
+			enc.SetIndent(2)
+			enc.Encode(yaml.Node{
+				Kind: yaml.MappingNode,
+				Tag:  visit.ShortTagMap,
+				Content: []*yaml.Node{
+					stage.Node.Key.Node,
+					stage.Node.Value,
+				},
+			})
+			writer.WriteString("\n")
+		}
+
+		writer.Close()
+
+		return nil
+	},
+}
+
+func init() {
+	varsCmd.AddCommand(varsYMLCmd)
+
+	addWharfYmlStageFlag(varsYMLCmd, varsYMLCmd.Flags(), &varsYMLFlags.stage)
+}

--- a/pkg/wharfyml/stage.go
+++ b/pkg/wharfyml/stage.go
@@ -22,16 +22,22 @@ type Stage struct {
 	Envs    []EnvRef
 	EnvsPos visit.Pos
 	Steps   []Step
+
+	Node visit.MapItem
 }
 
-func visitStageNode(nameNode visit.StringNode, node *yaml.Node, args Args, source varsub.Source) (stage Stage, errSlice errutil.Slice) {
-	stage.Pos = visit.NewPosFromNode(node)
-	stage.Name = nameNode.Value
+func visitStageNode(nameNode visit.StringNode, node *yaml.Node, args Args, source varsub.Source) (Stage, errutil.Slice) {
+	var errSlice errutil.Slice
+	stage := Stage{
+		Pos:  visit.NewPosFromNode(node),
+		Name: nameNode.Value,
+		Node: visit.MapItem{Key: nameNode, Value: node},
+	}
 	nodes, errs := visit.MapSlice(node)
 	errSlice.Add(errs...)
 	if len(nodes) == 0 {
 		errSlice.Add(errutil.NewPosFromNode(ErrStageEmpty, node))
-		return
+		return stage, errSlice
 	}
 	for _, stepNode := range nodes {
 		switch stepNode.Key.Value {
@@ -46,5 +52,5 @@ func visitStageNode(nameNode visit.StringNode, node *yaml.Node, args Args, sourc
 			errSlice.Add(errutil.ScopeSlice(errs, stepNode.Key.Value)...)
 		}
 	}
-	return
+	return stage, errSlice
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added new command `wharf vars yml` that prints the parsed `.wharf-ci.yml` file

## Motivation

Utility command that helps when debugging your build pipeline

## Preview

```console
$ cat .wharf-ci.yml
build:
  wharf-cmd:
    docker:
      file: Dockerfile
      tag: canary
      args:
        - BUILD_VERSION=${GIT_BRANCH}
        - BUILD_GIT_COMMIT=${GIT_COMMIT}
        - BUILD_REF=${BUILD_REF}
        - REG=${REG_URL}/hub

$ wharf vars yml
build:
  wharf-cmd:
    docker:
      file: Dockerfile
      tag: canary
      args:
        - BUILD_VERSION=feature/wharf-vars-yml-help-cmd
        - BUILD_GIT_COMMIT=c21b715a2b43d4b91f8c789c03da64e387720009
        - BUILD_REF=${BUILD_REF}
        - REG=harbor.local/hub
```

The `${BUILD_REF}` above isn't substituted because that's fixed in a different PR: #175
