### PR TITLE
Minor fixes

### DIFF
--- a/cmd/wharf/utils.go
+++ b/cmd/wharf/utils.go
@@ -254,9 +254,9 @@ func newBuildIDVarSource(buildID uint) varsub.Source {
 			"%s, or next ID from %s", sourceName, pathutil.ShorthandHome(path))
 	}
 	return varsub.SourceVar{
-		Key:    "BUILD_REF",
-		Value:  buildID,
-		Source: sourceName,
+		Key:         "BUILD_REF",
+		Value:       buildID,
+		SourceLabel: sourceName,
 	}
 }
 

--- a/cmd/wharf/vars_list.go
+++ b/cmd/wharf/vars_list.go
@@ -69,7 +69,7 @@ environment variables, such as:
 		}
 
 		groups := slices.GroupBy(vars, func(v varsub.Var) string {
-			return v.Source
+			return v.SourceLabel
 		})
 		slices.Reverse(groups)
 
@@ -89,8 +89,8 @@ environment variables, such as:
 			for _, value := range g.Values {
 				v, _ := def.VarSource.Lookup(value.Key)
 				vars = append(vars, variable{
-					Var:    v,
-					isUsed: v.Source == value.Source,
+					Var:    value,
+					isUsed: v.SourceLabel == value.SourceLabel,
 				})
 			}
 

--- a/internal/gitutil/stats.go
+++ b/internal/gitutil/stats.go
@@ -75,9 +75,9 @@ func (s Stats) Lookup(name string) (varsub.Var, bool) {
 		return varsub.Var{}, false
 	}
 	return varsub.Var{
-		Key:    name,
-		Value:  value,
-		Source: "git",
+		Key:         name,
+		Value:       value,
+		SourceLabel: "git",
 	}, true
 }
 

--- a/pkg/steps/container.go
+++ b/pkg/steps/container.go
@@ -108,13 +108,11 @@ func (s Container) applyStep() v1.PodSpec {
 			1, // TODO: Use project ID
 			s.SecretName,
 		)
-		optional := true
 		cont.EnvFrom = append(cont.EnvFrom, v1.EnvFromSource{
 			SecretRef: &v1.SecretEnvSource{
 				LocalObjectReference: v1.LocalObjectReference{
 					Name: secretName,
 				},
-				Optional: &optional,
 			},
 		})
 	}

--- a/pkg/steps/docker.go
+++ b/pkg/steps/docker.go
@@ -264,7 +264,6 @@ func (s Docker) applyStep(v visit.MapVisitor) (v1.PodSpec, errutil.Slice) {
 			1, // TODO: Use project ID
 			s.SecretName,
 		)
-		optional := true
 		for _, arg := range s.SecretArgs {
 			argName, secretKey, hasCut := strings.Cut(arg, "=")
 			if !hasCut || len(argName) == 0 || len(secretKey) == 0 {
@@ -278,8 +277,7 @@ func (s Docker) applyStep(v visit.MapVisitor) (v1.PodSpec, errutil.Slice) {
 						LocalObjectReference: v1.LocalObjectReference{
 							Name: secretName,
 						},
-						Key:      secretKey,
-						Optional: &optional,
+						Key: secretKey,
 					},
 				},
 			})

--- a/pkg/varsub/osenvsource.go
+++ b/pkg/varsub/osenvsource.go
@@ -27,9 +27,9 @@ func (s osEnvSource) Lookup(name string) (Var, bool) {
 		return Var{}, false
 	}
 	return Var{
-		Key:    name,
-		Value:  val,
-		Source: osEnvSourceName,
+		Key:         name,
+		Value:       val,
+		SourceLabel: osEnvSourceName,
 	}, true
 }
 
@@ -48,9 +48,9 @@ func (s osEnvSource) ListVars() []Var {
 			continue
 		}
 		vars = append(vars, Var{
-			Key:    trimmedKey,
-			Value:  val,
-			Source: osEnvSourceName,
+			Key:         trimmedKey,
+			Value:       val,
+			SourceLabel: osEnvSourceName,
 		})
 	}
 	return vars

--- a/pkg/varsub/source.go
+++ b/pkg/varsub/source.go
@@ -34,9 +34,9 @@ func (s SourceVar) ListVars() []Var {
 // Var is a single varsub variable, with it's Key (name), Value, and optionally
 // also a Source that declares where this variable comes from.
 type Var struct {
-	Key    string
-	Value  any
-	Source string
+	Key         string
+	Value       any
+	SourceLabel string
 }
 
 // String implements the fmt.Stringer interface.
@@ -99,9 +99,9 @@ type SourceMap map[string]Val
 func (s SourceMap) Lookup(name string) (Var, bool) {
 	v, ok := s[name]
 	return Var{
-		Key:    name,
-		Value:  v.Value,
-		Source: v.Source,
+		Key:         name,
+		Value:       v.Value,
+		SourceLabel: v.Source,
 	}, ok
 }
 
@@ -114,9 +114,9 @@ func (s SourceMap) ListVars() []Var {
 	var vars []Var
 	for k, v := range s {
 		vars = append(vars, Var{
-			Key:    k,
-			Value:  v.Value,
-			Source: v.Source,
+			Key:         k,
+			Value:       v.Value,
+			SourceLabel: v.Source,
 		})
 	}
 	return vars


### PR DESCRIPTION
## Summary

- Changed secret mounts to be required
- Renamed field `varsub.Var.Source` -> `.SourceLabel`, to not confuse it with `varsub.Source`

## Motivation

The secrets should fail the build instead of silently continue.
