### PR TITLE
Fixed build status always set to Failed despite being successful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v0.8.2 (WIP)
+
+- Fixed build status always being set to `Failed`. (#189)
+
 ## v0.8.1 (2022-05-20)
 
 - Removed `replace` directive from `go.mod`, making `go install ...` fail.

--- a/pkg/aggregator/k8saggregator.go
+++ b/pkg/aggregator/k8saggregator.go
@@ -210,7 +210,7 @@ func (a k8sAggr) handleRunningPod(ctx context.Context, pod workerPod) error {
 		if err != nil {
 			return err
 		}
-		return pipeAndClose(statusEventsPiper)
+		return pipeAndClose(&statusEventsPiper)
 	})
 	pg.AddFunc("artifact events", func(ctx context.Context) error {
 		artifactEventsPiper, err := newArtifactEventsPiper(ctx, a.wharfapi, worker)

--- a/pkg/aggregator/piper_statusevents.go
+++ b/pkg/aggregator/piper_statusevents.go
@@ -110,7 +110,7 @@ func (p *statusEventsPiper) transformStatus(status v1.Status) (request.BuildStat
 func (p *statusEventsPiper) writeStatus(status request.BuildStatus) error {
 	statusUpdate := request.LogOrStatusUpdate{Status: status}
 	_, err := p.wharfapi.UpdateBuildStatus(p.worker.BuildID(), statusUpdate)
-	if err != nil {
+	if err == nil {
 		p.prevStatus = status
 	}
 	return err

--- a/pkg/aggregator/piper_statusevents.go
+++ b/pkg/aggregator/piper_statusevents.go
@@ -32,7 +32,7 @@ func newStatusEventsPiper(ctx context.Context, wharfapi wharfapi.Client, worker 
 	}, nil
 }
 
-func (p statusEventsPiper) PipeMessage() error {
+func (p *statusEventsPiper) PipeMessage() error {
 	status, err := p.readStatus()
 	if err != nil {
 		if errors.Is(err, io.EOF) {
@@ -58,7 +58,7 @@ func (p statusEventsPiper) PipeMessage() error {
 }
 
 // Close closes all active streams.
-func (p statusEventsPiper) Close() error {
+func (p *statusEventsPiper) Close() error {
 	if err := p.in.CloseSend(); err != nil {
 		log.Error().
 			WithError(err).
@@ -67,7 +67,7 @@ func (p statusEventsPiper) Close() error {
 	return nil
 }
 
-func (p statusEventsPiper) readStatus() (*workerclient.StatusEvent, error) {
+func (p *statusEventsPiper) readStatus() (*workerclient.StatusEvent, error) {
 	if p.in == nil {
 		return nil, errors.New("input stream is nil")
 	}
@@ -78,7 +78,7 @@ func (p statusEventsPiper) readStatus() (*workerclient.StatusEvent, error) {
 	return status, nil
 }
 
-func (p statusEventsPiper) ensureStatusCompletedOrFailed() error {
+func (p *statusEventsPiper) ensureStatusCompletedOrFailed() error {
 	if p.prevStatus != request.BuildCompleted && p.prevStatus != request.BuildFailed {
 		finalStatus, _ := p.transformStatus(v1.StatusFailed)
 		if err := p.writeStatus(finalStatus); err != nil {
@@ -88,11 +88,11 @@ func (p statusEventsPiper) ensureStatusCompletedOrFailed() error {
 	return nil
 }
 
-func (p statusEventsPiper) shouldSkip(status request.BuildStatus) bool {
+func (p *statusEventsPiper) shouldSkip(status request.BuildStatus) bool {
 	return status == p.prevStatus
 }
 
-func (p statusEventsPiper) transformStatus(status v1.Status) (request.BuildStatus, error) {
+func (p *statusEventsPiper) transformStatus(status v1.Status) (request.BuildStatus, error) {
 	switch status {
 	case v1.StatusPending, v1.StatusScheduling:
 		return request.BuildScheduling, nil
@@ -107,7 +107,7 @@ func (p statusEventsPiper) transformStatus(status v1.Status) (request.BuildStatu
 	}
 }
 
-func (p statusEventsPiper) writeStatus(status request.BuildStatus) error {
+func (p *statusEventsPiper) writeStatus(status request.BuildStatus) error {
 	statusUpdate := request.LogOrStatusUpdate{Status: status}
 	_, err := p.wharfapi.UpdateBuildStatus(p.worker.BuildID(), statusUpdate)
 	if err != nil {


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed `statusEventsPiper`'s methods to use a pointer-receiver instead.

## Motivation

Closes #188