### PR TITLE
Release v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v0.8.3 (WIP)
+## v0.8.3 (2022-06-02)
 
 - Fixed installing via `go install github.com/iver-wharf/wharf-cmd/cmd/wharf@latest`
   not working. (#192)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v0.8.3 (2022-06-02)
+## v0.8.3 (2022-06-03)
 
 - Fixed installing via `go install github.com/iver-wharf/wharf-cmd/cmd/wharf@latest`
   not working. (#192)


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- Fixed installing via `go install github.com/iver-wharf/wharf-cmd/cmd/wharf@latest`
  not working. (#192)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
