### PR TITLE
Added conditional running of stages

### DIFF
--- a/pkg/wharfyml/magicstrings.go
+++ b/pkg/wharfyml/magicstrings.go
@@ -4,6 +4,7 @@ const (
 	// Map keys in .wharf-ci.yml
 	propInputs       = "inputs"
 	propEnvironments = "environments"
+	propRunsIf       = "runs-if"
 
 	// Map keys in .wharf-vars.yml
 	propVars = "vars"

--- a/pkg/wharfyml/runsif.go
+++ b/pkg/wharfyml/runsif.go
@@ -1,0 +1,47 @@
+package wharfyml
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/iver-wharf/wharf-cmd/internal/errutil"
+	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml/visit"
+	"gopkg.in/yaml.v3"
+)
+
+// Errors related to parsing the run conditions.
+var (
+	ErrInvalidRunCondition = errors.New("invalid run condition")
+)
+
+// StageRunsIf is an enum of different run behaviors for a stage, dependent on
+// previous stages.
+type StageRunsIf string
+
+const (
+	// StageRunsIfSuccess runs the stage if all previous stages were successful.
+	StageRunsIfSuccess = "success"
+	// StageRunsIfFail runs the stage if one or more of the previous stages were
+	// unsuccessful.
+	StageRunsIfFail = "fail"
+	// StageRunsIfAlways always runs the stage, regardless of the success state
+	// of previous stages.
+	StageRunsIfAlways = "always"
+)
+
+func visitStageRunsIfNode(node *yaml.Node) (StageRunsIf, errutil.Slice) {
+	runsIfStr, err := visit.String(node)
+	if err != nil {
+		return "", []error{err}
+	}
+	runsIf := StageRunsIf(strings.ToLower(runsIfStr))
+	switch runsIf {
+	case StageRunsIfAlways, StageRunsIfFail, StageRunsIfSuccess:
+		return runsIf, nil
+	default:
+		err := fmt.Errorf("%w: '%s' must be one of 'always', 'success', or 'fail'", ErrInvalidRunCondition, runsIf)
+		posErr := errutil.NewPosFromNode(err, node)
+		return "", []error{posErr}
+	}
+}

--- a/pkg/wharfyml/runsif_test.go
+++ b/pkg/wharfyml/runsif_test.go
@@ -1,0 +1,31 @@
+package wharfyml
+
+import (
+	"testing"
+
+	"github.com/iver-wharf/wharf-cmd/internal/testutil"
+	"github.com/iver-wharf/wharf-cmd/pkg/wharfyml/visit"
+)
+
+func TestVisitRunsIf_ErrIfNotString(t *testing.T) {
+	node := testutil.NewNode(t, "123")
+	_, errs := visitStageRunsIfNode(node)
+	testutil.RequireContainsErr(t, errs, visit.ErrInvalidFieldType)
+}
+
+func TestVisitRunsIf_ErrIfNotValidValue(t *testing.T) {
+	node := testutil.NewNode(t, "badvalue")
+	_, errs := visitStageRunsIfNode(node)
+	testutil.RequireContainsErr(t, errs, ErrInvalidRunCondition)
+}
+
+func TestVisitRunsIf_Success(t *testing.T) {
+	testCases := []string{"success", "always", "fail"}
+	for _, tc := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			node := testutil.NewNode(t, tc)
+			_, errs := visitStageRunsIfNode(node)
+			testutil.RequireNoErr(t, errs)
+		})
+	}
+}

--- a/test/condition/.wharf-ci.yml
+++ b/test/condition/.wharf-ci.yml
@@ -1,0 +1,70 @@
+test:
+  step1:
+    container:
+      image: alpine:latest
+      cmds:
+      - echo 'hello everybody :)'
+
+# should run
+test-run-on-success-1:
+  # default behavior
+  runs-if: success
+  step1:
+    container:
+      image: alpine:latest
+      cmds:
+      - echo 'all previous stage(s) succeeded, GOOD'
+
+# should run
+test-run-on-always-1:
+  runs-if: always
+  step1:
+    container:
+      image: alpine:latest
+      cmds:
+      - echo 'this always runs, GOOD'
+
+# should not run
+test-run-on-fail-1:
+  runs-if: fail
+  step1:
+    container:
+      image: alpine:latest
+      cmds:
+      - echo 'one or more of previous stages failed?? BAD'
+
+# should fail
+failing-stage:
+  my-step:
+    container:
+      image: alpine:latest
+      cmds:
+      - echo "writing to non-existing file should fail" > /non/existing/file
+
+# should not run
+test-run-on-success-2:
+  # default behavior
+  runs-if: success
+  step1:
+    container:
+      image: alpine:latest
+      cmds:
+      - echo 'all previous stage(s) succeeded?? BAD!! should not run'
+
+# should run
+test-run-on-fail-2:
+  runs-if: fail
+  step1:
+    container:
+      image: alpine:latest
+      cmds:
+      - echo 'one or more of previous stages failed, GOOD'
+
+# should run
+test-run-on-always-2:
+  runs-if: always
+  step1:
+    container:
+      image: alpine:latest
+      cmds:
+      - echo 'this always runs, GOOD'


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added a `runs-if` field to stages in the `.wharf-ci.yml` file, with the following possible values:
  - `success`, the default behavior, runs if all previous stages succeeded.
  - `fail`, runs if one or more of the previous stages failed.
  - `always`, always runs.

## Motivation

Partial completion of #146.