### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v0.9.0 (WIP)
+## v0.9.0 (2022-06-27)
 
 - Added `run-if` field to stages in the `.wharf-ci.yml` file. Allows one of
   the values: `success`, `fail`, `always`. (#195)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v0.9.0 (2022-06-27)
+## v0.9.0 (2022-06-28)
 
 - Added `run-if` field to stages in the `.wharf-ci.yml` file. Allows one of
   the values: `success`, `fail`, `always`. (#195)

--- a/pkg/provisioner/provisionerserver/docs/provisionerapi_docs.go
+++ b/pkg/provisioner/provisionerserver/docs/provisionerapi_docs.go
@@ -254,7 +254,7 @@ const docTemplateprovisionerapi = `{
 
 // SwaggerInfoprovisionerapi holds exported Swagger Info so clients can modify it
 var SwaggerInfoprovisionerapi = &swag.Spec{
-	Version:          "",
+	Version:          "v0.9.0",
 	Host:             "",
 	BasePath:         "",
 	Schemes:          []string{},

--- a/pkg/provisioner/provisionerserver/docs/provisionerapi_swagger.json
+++ b/pkg/provisioner/provisionerserver/docs/provisionerapi_swagger.json
@@ -11,7 +11,8 @@
         "license": {
             "name": "MIT",
             "url": "https://github.com/iver-wharf/wharf-cmd/blob/master/LICENSE"
-        }
+        },
+        "version": "v0.9.0"
     },
     "paths": {
         "/": {

--- a/pkg/provisioner/provisionerserver/docs/provisionerapi_swagger.yaml
+++ b/pkg/provisioner/provisionerserver/docs/provisionerapi_swagger.yaml
@@ -26,6 +26,7 @@ info:
     name: MIT
     url: https://github.com/iver-wharf/wharf-cmd/blob/master/LICENSE
   title: Wharf provisioner API
+  version: v0.9.0
 paths:
   /:
     get:

--- a/pkg/provisioner/provisionerserver/provisionerserver.go
+++ b/pkg/provisioner/provisionerserver/provisionerserver.go
@@ -17,6 +17,7 @@ var log = logger.NewScoped("PROV-SERVER")
 // Serve starts an HTTP server.
 //
 // @title Wharf provisioner API
+// @version v0.9.0
 // @description REST API for wharf-cmd to provision wharf-cmd-workers.
 // @license.name MIT
 // @license.url https://github.com/iver-wharf/wharf-cmd/blob/master/LICENSE

--- a/pkg/worker/workerserver/docs/workerapi_docs.go
+++ b/pkg/worker/workerserver/docs/workerapi_docs.go
@@ -150,7 +150,7 @@ const docTemplateworkerapi = `{
 
 // SwaggerInfoworkerapi holds exported Swagger Info so clients can modify it
 var SwaggerInfoworkerapi = &swag.Spec{
-	Version:          "",
+	Version:          "v0.9.0",
 	Host:             "",
 	BasePath:         "",
 	Schemes:          []string{},

--- a/pkg/worker/workerserver/docs/workerapi_swagger.json
+++ b/pkg/worker/workerserver/docs/workerapi_swagger.json
@@ -11,7 +11,8 @@
         "license": {
             "name": "MIT",
             "url": "https://github.com/iver-wharf/wharf-cmd/blob/master/LICENSE"
-        }
+        },
+        "version": "v0.9.0"
     },
     "paths": {
         "/": {

--- a/pkg/worker/workerserver/docs/workerapi_swagger.yaml
+++ b/pkg/worker/workerserver/docs/workerapi_swagger.yaml
@@ -71,6 +71,7 @@ info:
     name: MIT
     url: https://github.com/iver-wharf/wharf-cmd/blob/master/LICENSE
   title: Wharf worker API
+  version: v0.9.0
 paths:
   /:
     get:

--- a/pkg/worker/workerserver/restserver.go
+++ b/pkg/worker/workerserver/restserver.go
@@ -23,6 +23,7 @@ func newRestServer(artifactOpener ArtifactFileOpener) *restServer {
 
 // serveHTTP godoc
 // @title Wharf worker API
+// @version v0.9.0
 // @description REST API for wharf-cmd to access build results.
 // @description Please refer to the gRPC API for more endpoints.
 // @license.name MIT


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- Added `run-if` field to stages in the `.wharf-ci.yml` file. Allows one of
  the values: `success`, `fail`, `always`. (#195)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
