### PR TITLE
Release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v0.9.1 (WIP)
+## v0.9.1 (2022-06-28)
 
 - Fixed CVE-2022-1586 (High) and CVE-2022-1587 (High). (#198)
 

--- a/pkg/provisioner/provisionerserver/docs/provisionerapi_docs.go
+++ b/pkg/provisioner/provisionerserver/docs/provisionerapi_docs.go
@@ -254,7 +254,7 @@ const docTemplateprovisionerapi = `{
 
 // SwaggerInfoprovisionerapi holds exported Swagger Info so clients can modify it
 var SwaggerInfoprovisionerapi = &swag.Spec{
-	Version:          "v0.9.0",
+	Version:          "v0.9.1",
 	Host:             "",
 	BasePath:         "",
 	Schemes:          []string{},

--- a/pkg/provisioner/provisionerserver/docs/provisionerapi_swagger.json
+++ b/pkg/provisioner/provisionerserver/docs/provisionerapi_swagger.json
@@ -12,7 +12,7 @@
             "name": "MIT",
             "url": "https://github.com/iver-wharf/wharf-cmd/blob/master/LICENSE"
         },
-        "version": "v0.9.0"
+        "version": "v0.9.1"
     },
     "paths": {
         "/": {

--- a/pkg/provisioner/provisionerserver/docs/provisionerapi_swagger.yaml
+++ b/pkg/provisioner/provisionerserver/docs/provisionerapi_swagger.yaml
@@ -26,7 +26,7 @@ info:
     name: MIT
     url: https://github.com/iver-wharf/wharf-cmd/blob/master/LICENSE
   title: Wharf provisioner API
-  version: v0.9.0
+  version: v0.9.1
 paths:
   /:
     get:

--- a/pkg/provisioner/provisionerserver/provisionerserver.go
+++ b/pkg/provisioner/provisionerserver/provisionerserver.go
@@ -17,7 +17,7 @@ var log = logger.NewScoped("PROV-SERVER")
 // Serve starts an HTTP server.
 //
 // @title Wharf provisioner API
-// @version v0.9.1-rc.1
+// @version v0.9.1
 // @description REST API for wharf-cmd to provision wharf-cmd-workers.
 // @license.name MIT
 // @license.url https://github.com/iver-wharf/wharf-cmd/blob/master/LICENSE

--- a/pkg/worker/workerserver/docs/workerapi_docs.go
+++ b/pkg/worker/workerserver/docs/workerapi_docs.go
@@ -150,7 +150,7 @@ const docTemplateworkerapi = `{
 
 // SwaggerInfoworkerapi holds exported Swagger Info so clients can modify it
 var SwaggerInfoworkerapi = &swag.Spec{
-	Version:          "v0.9.0",
+	Version:          "v0.9.1",
 	Host:             "",
 	BasePath:         "",
 	Schemes:          []string{},

--- a/pkg/worker/workerserver/docs/workerapi_swagger.json
+++ b/pkg/worker/workerserver/docs/workerapi_swagger.json
@@ -12,7 +12,7 @@
             "name": "MIT",
             "url": "https://github.com/iver-wharf/wharf-cmd/blob/master/LICENSE"
         },
-        "version": "v0.9.0"
+        "version": "v0.9.1"
     },
     "paths": {
         "/": {

--- a/pkg/worker/workerserver/docs/workerapi_swagger.yaml
+++ b/pkg/worker/workerserver/docs/workerapi_swagger.yaml
@@ -71,7 +71,7 @@ info:
     name: MIT
     url: https://github.com/iver-wharf/wharf-cmd/blob/master/LICENSE
   title: Wharf worker API
-  version: v0.9.0
+  version: v0.9.1
 paths:
   /:
     get:

--- a/pkg/worker/workerserver/restserver.go
+++ b/pkg/worker/workerserver/restserver.go
@@ -23,7 +23,7 @@ func newRestServer(artifactOpener ArtifactFileOpener) *restServer {
 
 // serveHTTP godoc
 // @title Wharf worker API
-// @version v0.9.1-rc.1
+// @version v0.9.1
 // @description REST API for wharf-cmd to access build results.
 // @description Please refer to the gRPC API for more endpoints.
 // @license.name MIT


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- Fixed CVE-2022-1586 (High) and CVE-2022-1587 (High). (#198)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
